### PR TITLE
Abort if no valid session is running when trying to send a custom event

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -188,6 +188,7 @@ public final class ConvivaAnalytics: NSObject {
     public func sendCustomPlaybackEvent(name: String, attributes: [String: String] = [:]) {
         if !isValidSession {
             logger.debugLog(message: "Cannot send playback event, no active monitoring session")
+            return
         }
         client.sendCustomEvent(sessionKey, eventname: name, withAttributes: attributes)
     }


### PR DESCRIPTION
## Description
Logging the message 'cannot send' and trying to send anyway might be not the best approach.