### PR TITLE
Content metadata on init

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -123,11 +123,7 @@ public final class ConvivaAnalytics: NSObject {
         if !isValidSession {
             return
         }
-        if !player.isLive {
-            contentMetadata.duration = Int(player.duration)
-        }
-        contentMetadata.streamType = player.isLive ? .CONVIVA_STREAM_LIVE : .CONVIVA_STREAM_VOD
-        contentMetadata.streamUrl = player.config.sourceItem?.url(forType: player.streamType)?.absoluteString
+        buildDynamicContentMetadata()
 
         if let videoQuality = player.videoQuality {
             let bitrate = Int(videoQuality.bitrate) / 1000 // in kbps
@@ -162,6 +158,15 @@ public final class ConvivaAnalytics: NSObject {
             customInternTags.merge(customTags) { (_, new) in new }
         }
         contentMetadata.custom = NSMutableDictionary(dictionary: customInternTags)
+        buildDynamicContentMetadata()
+    }
+
+    private func buildDynamicContentMetadata() {
+        if !player.isLive {
+            contentMetadata.duration = Int(player.duration)
+        }
+        contentMetadata.streamType = player.isLive ? .CONVIVA_STREAM_LIVE : .CONVIVA_STREAM_VOD
+        contentMetadata.streamUrl = player.config.sourceItem?.url(forType: player.streamType)?.absoluteString
     }
 
     // MARK: - event handling

--- a/Example/Tests/ContentMetadataTests.swift
+++ b/Example/Tests/ContentMetadataTests.swift
@@ -46,7 +46,7 @@ class ContentMetadataSpec: QuickSpec {
             context("when initializing session") {
                 it("set application name") {
                     playerDouble.fakePlayEvent() // to initialize session
-                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "updateContentMetadata")
+                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "createSession")
 
                     expect(spy).to(
                         haveBeenCalled(withArgs: ["applicationName": "Unit Tests"])
@@ -54,7 +54,7 @@ class ContentMetadataSpec: QuickSpec {
                 }
 
                 it("set asset name") {
-                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "updateContentMetadata")
+                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "createSession")
 
                     let playerConfiguration = PlayerConfiguration()
                     let sourceItem = SourceItem(url: URL(string: "www.google.com.m3u8")!)!
@@ -71,7 +71,7 @@ class ContentMetadataSpec: QuickSpec {
 
                 it("set viewer id") {
                     playerDouble.fakePlayEvent() // to initialize session
-                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "updateContentMetadata")
+                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "createSession")
                     expect(spy).to(
                         haveBeenCalled(withArgs: ["viewerId": "TestViewer"])
                     )
@@ -79,9 +79,27 @@ class ContentMetadataSpec: QuickSpec {
 
                 it("set custom tags") {
                     playerDouble.fakePlayEvent() // to initialize session
-                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "updateContentMetadata")
+                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "createSession")
                     expect(spy).to(
                         haveBeenCalled(withArgs: ["Custom": "Tags", "TestRun": "Success"])
+                    )
+                }
+
+                it("set stream url") {
+                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "createSession")
+
+                    let playerConfiguration = PlayerConfiguration()
+                    let sourceItem = SourceItem(url: URL(string: "www.google.com.m3u8")!)!
+                    sourceItem.itemTitle = "Art of Unit Test"
+                    playerConfiguration.sourceItem = sourceItem
+
+                    _ = TestDouble(aClass: playerDouble, name: "config", return: playerConfiguration)
+                    _ = TestDouble(aClass: playerDouble, name: "streamType", return: BMPMediaSourceType.HLS)
+
+                    playerDouble.fakePlayEvent() // to initialize session
+
+                    expect(spy).to(
+                        haveBeenCalled(withArgs: ["streamUrl": "www.google.com.m3u8"])
                     )
                 }
             }

--- a/Example/Tests/CustomEventTests.swift
+++ b/Example/Tests/CustomEventTests.swift
@@ -34,6 +34,9 @@ class CustomEventsSpec: QuickSpec {
 
             it("send custom playback event") {
                 let spy = Spy(aClass: CISClientTestDouble.self, functionName: "sendCustomEvent")
+
+                playerDouble.fakePlayEvent() // to initialize session
+
                 convivaAnalytics.sendCustomPlaybackEvent(name: "Playback Event",
                                                          attributes: ["Test Case": "Playback"])
                 expect(spy).to(

--- a/Example/Tests/Doubles/CISClientTestDouble.swift
+++ b/Example/Tests/Doubles/CISClientTestDouble.swift
@@ -11,7 +11,7 @@ import ConvivaSDK
 
 class CISClientTestDouble: NSObject, CISClientProtocol, TestDoubleDataSource {
     func createSession(with cisContentMetadata: CISContentMetadata!) -> Int32 {
-        spy(functionName: "createSession")
+        spy(functionName: "createSession", args: metaDataToArgs(contentMetadata: cisContentMetadata))
         return Int32(0)
     }
 
@@ -24,25 +24,7 @@ class CISClientTestDouble: NSObject, CISClientProtocol, TestDoubleDataSource {
     }
 
     func updateContentMetadata(_ sessionKey: Int32, metadata contentMetadata: CISContentMetadata!) {
-        var args: [String: String] = [:]
-        // content metadata
-        args["applicationName"] = contentMetadata.applicationName
-        args["viewerId"] = contentMetadata.viewerId
-        for key in contentMetadata.custom.allKeys {
-            if let keyString = key as? String {
-                if let value = contentMetadata.custom.value(forKey: keyString) as? String {
-                    args[keyString] = value
-                }
-            }
-        }
-        args["assetName"] = contentMetadata.assetName
-
-        // update session metadata
-        args["duration"] = "\(contentMetadata.duration)"
-        args["streamType"] = "\(contentMetadata.streamType.rawValue)"
-        args["streamUrl"] = contentMetadata.streamUrl
-
-        spy(functionName: "updateContentMetadata", args: args)
+        spy(functionName: "updateContentMetadata", args: metaDataToArgs(contentMetadata: contentMetadata))
     }
 
     func sendCustomEvent(_ sessionKey: Int32,
@@ -90,4 +72,27 @@ class CISClientTestDouble: NSObject, CISClientProtocol, TestDoubleDataSource {
     func contentStart(_ sessionKey: Int32) {}
     func cleanUp() {}
     func attachPlayer(_ sessionKey: Int32, playerStateManager: CISPlayerStateManagerProtocol!) {}
+
+    // MARK: - private helper
+    private func metaDataToArgs(contentMetadata: CISContentMetadata) -> [String: String] {
+        var args: [String: String] = [:]
+        // content metadata
+        args["applicationName"] = contentMetadata.applicationName
+        args["viewerId"] = contentMetadata.viewerId
+        for key in contentMetadata.custom.allKeys {
+            if let keyString = key as? String {
+                if let value = contentMetadata.custom.value(forKey: keyString) as? String {
+                    args[keyString] = value
+                }
+            }
+        }
+        args["assetName"] = contentMetadata.assetName
+
+        // update session metadata
+        args["duration"] = "\(contentMetadata.duration)"
+        args["streamType"] = "\(contentMetadata.streamType.rawValue)"
+        args["streamUrl"] = contentMetadata.streamUrl
+
+        return args
+    }
 }


### PR DESCRIPTION
## Description
Some `contentMetadata` attributes weren't set when initializing a conviva session.
This PR adds all available attributes at the session initialization.

## Tests
- added new test to check if streamUrl is set on session initialization
- fixed failing test for custom playback events