### PR TITLE
Update dependency

### DIFF
--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -20,8 +20,8 @@ Conviva Analytics Integration for the Bitmovin Player iOS SDK
   s.swift_version = '4.2'
   s.cocoapods_version = '>= 1.4.0'
 
-  s.ios.dependency 'BitmovinPlayer', '~> 2.0'
-  s.tvos.dependency 'BitmovinPlayer', '~> 2.0'
+  s.ios.dependency 'BitmovinPlayer', '~> 2.17'
+  s.tvos.dependency 'BitmovinPlayer', '~> 2.17'
   s.ios.dependency 'ConvivaSDK', '~> 2.141.0'
   s.tvos.dependency 'ConvivaSDK', '~> 2.141.0'
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ BitmovinConvivaAnalytics is available through [CocoaPods](https://cocoapods.org)
 To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'BitmovinConvivaAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git', tag: '1.0.0'
+pod 'BitmovinConvivaAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git', tag: '1.1.0'
 ```
 
 Then, in your command line run:
@@ -15,6 +15,9 @@ Then, in your command line run:
 ```
 pod install
 ```
+
+### Support
+This version of the Conviva Analytics Integration depends on `BitmovinPlayer` version `>= 2.17.x`. If you need support for prior `2.17.x` please use [v1.0.0](https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva/tree/1.0.0).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then, in your command line run:
 pod install
 ```
 
-### Support
+### Compatibility
 This version of the Conviva Analytics Integration depends on `BitmovinPlayer` version `>= 2.17.x`. If you need support for prior `2.17.x` please use [v1.0.0](https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva/tree/1.0.0).
 
 ## Usage


### PR DESCRIPTION
## Description
Since `v1.1.0` rely on the `onPlaying` event this version will not work with prior `BitmovinPlayer` versions. So this PR will update the dependency within the podspec file as well as update the usage description in the readme.