### PR TITLE
Externally session managing

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -241,10 +241,6 @@ public final class ConvivaAnalytics: NSObject {
             return
         }
 
-        if !isSessionActive {
-            self.internalInitializeSession()
-        }
-
         playerStateManager.setPlayerState!(playerState)
         logger.debugLog(message: "Player state changed: \(playerState.rawValue)")
     }

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalyticsError.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalyticsError.swift
@@ -1,0 +1,21 @@
+//
+//  ConvivaAnalyticsError.swift
+//  BitmovinConvivaAnalytics-iOS
+//
+//  Created by Bitmovin on 31.01.19.
+//  Copyright (c) 2018 Bitmovin. All rights reserved.
+//
+
+import Foundation
+
+public struct ConvivaAnalytisError: Error {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    public var localizedDescription: String {
+        return message
+    }
+}

--- a/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
+++ b/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		37756EC0216F9A510041806D /* ContentMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EBF216F9A510041806D /* ContentMetadataTests.swift */; };
 		37756EC2216F9AA50041806D /* CustomEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EC1216F9AA50041806D /* CustomEventTests.swift */; };
 		37756EC42170764E0041806D /* SpecHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EC32170764E0041806D /* SpecHelper.swift */; };
+		37CE33382203067500E0286F /* ExternallyManagedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CE33372203067500E0286F /* ExternallyManagedSessionTests.swift */; };
 		37EB3CD3216B70D70093F085 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB3CD1216B70650093F085 /* TestHelper.swift */; };
 		37EB3CD4216B70DA0093F085 /* BitmovinPlayerTestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB3CC7216B6E3F0093F085 /* BitmovinPlayerTestDouble.swift */; };
 		37EB3CD5216B70DC0093F085 /* CISClientSettingCreatorTestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB3CC9216B6E8A0093F085 /* CISClientSettingCreatorTestDouble.swift */; };
@@ -73,6 +74,7 @@
 		37756EBF216F9A510041806D /* ContentMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMetadataTests.swift; sourceTree = "<group>"; };
 		37756EC1216F9AA50041806D /* CustomEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventTests.swift; sourceTree = "<group>"; };
 		37756EC32170764E0041806D /* SpecHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecHelper.swift; sourceTree = "<group>"; };
+		37CE33372203067500E0286F /* ExternallyManagedSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternallyManagedSessionTests.swift; sourceTree = "<group>"; };
 		37EB3CC7216B6E3F0093F085 /* BitmovinPlayerTestDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BitmovinPlayerTestDouble.swift; path = Doubles/BitmovinPlayerTestDouble.swift; sourceTree = "<group>"; };
 		37EB3CC9216B6E8A0093F085 /* CISClientSettingCreatorTestDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CISClientSettingCreatorTestDouble.swift; path = Doubles/CISClientSettingCreatorTestDouble.swift; sourceTree = "<group>"; };
 		37EB3CCB216B6ED30093F085 /* CISClientTestDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CISClientTestDouble.swift; path = Doubles/CISClientTestDouble.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				37756EBF216F9A510041806D /* ContentMetadataTests.swift */,
 				37756EC1216F9AA50041806D /* CustomEventTests.swift */,
 				607FACEB1AFB9204008FA782 /* SeekTimeshiftTests.swift */,
+				37CE33372203067500E0286F /* ExternallyManagedSessionTests.swift */,
 				37756EC32170764E0041806D /* SpecHelper.swift */,
 				37EB3CD1216B70650093F085 /* TestHelper.swift */,
 				37756EAE216F8DF00041806D /* Helpers */,
@@ -707,6 +710,7 @@
 				37EB3CD3216B70D70093F085 /* TestHelper.swift in Sources */,
 				37756EB2216F8E2F0041806D /* Spy.swift in Sources */,
 				37756EBA216F8FD30041806D /* SpyTracker.swift in Sources */,
+				37CE33382203067500E0286F /* ExternallyManagedSessionTests.swift in Sources */,
 				37756EB4216F8E450041806D /* TestDoubleDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/CustomEventTests.swift
+++ b/Example/Tests/CustomEventTests.swift
@@ -32,6 +32,12 @@ class CustomEventsSpec: QuickSpec {
                 }
             }
 
+            afterEach {
+                if convivaAnalytics != nil {
+                    convivaAnalytics = nil
+                }
+            }
+
             it("send custom playback event") {
                 let spy = Spy(aClass: CISClientTestDouble.self, functionName: "sendCustomEvent")
 

--- a/Example/Tests/ExternallyManagedSessionTests.swift
+++ b/Example/Tests/ExternallyManagedSessionTests.swift
@@ -1,0 +1,52 @@
+//
+//  ExternallyManagedSessionTests.swift
+//  BitmovinConvivaAnalytics_Tests
+//
+//  Created by Bitmovin on 11.10.18.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Quick
+import Nimble
+import BitmovinPlayer
+import BitmovinConvivaAnalytics
+import ConvivaSDK
+
+class ExternallyManagedSessionSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override func spec() {
+        var playerDouble: BitmovinPlayerTestDouble!
+
+        beforeEach {
+            playerDouble = BitmovinPlayerTestDouble()
+            TestHelper.shared.spyTracker.reset()
+            TestHelper.shared.mockTracker.reset()
+        }
+
+        context("Externally Managed Session") {
+            var convivaAnalytics: ConvivaAnalytics!
+            beforeEach {
+                do {
+                    convivaAnalytics = try ConvivaAnalytics(player: playerDouble, customerKey: "")
+                } catch {
+                    fail("ConvivaAnalytics failed with error: \(error)")
+                }
+            }
+
+            context("end session") {
+                it("no-opt if no session running") {
+                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "cleanupSession")
+                    convivaAnalytics.endSession()
+                    expect(spy).toNot(haveBeenCalled())
+                }
+
+                it("cleanup running session") {
+                    playerDouble.fakePlayEvent()
+                    let spy = Spy(aClass: CISClientTestDouble.self, functionName: "cleanupSession")
+                    convivaAnalytics.endSession()
+                    expect(spy).to(haveBeenCalled())
+                }
+            }
+        }
+    }
+}

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -82,6 +82,7 @@ class PlayerEventsSpec: QuickSpec {
             context("deinitialize player state manager") {
                 it("on playback finished") {
                     let spy = Spy(aClass: CISClientTestDouble.self, functionName: "releasePlayerStateManager")
+                    playerDouble.fakePlayEvent()
                     playerDouble.fakePlaybackFinishedEvent()
                     expect(spy).to(haveBeenCalled())
                 }
@@ -91,6 +92,7 @@ class PlayerEventsSpec: QuickSpec {
                 var spy: Spy!
                 beforeEach {
                     spy = Spy(aClass: PlayerStateManagerTestDouble.self, functionName: "setPlayerState")
+                    playerDouble.fakePlayEvent()
                 }
 
                 context("not") {
@@ -167,6 +169,7 @@ class PlayerEventsSpec: QuickSpec {
                 it("on playback finished") {
                     let playbackStateSpy = Spy(aClass: PlayerStateManagerTestDouble.self,
                                                functionName: "setPlayerState")
+                    playerDouble.fakePlayEvent()
                     playerDouble.fakePlaybackFinishedEvent()
                     expect(spy).to(haveBeenCalled())
                     expect(playbackStateSpy).to(

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ do {
 }
 ```
 
+### Background handling
+
+If your app stops playback when entering background conviva suggests to end the active session.
+Since the integration can't know if you app supports playback in background this can't be done automatically.
+
+To end a session use:
+```swift
+convivaAnalytics.endSession()
+```
+
+Since the `BitmovinPlayer` automatically pauses the video if no background playback is supported the session creation after
+the app is in foreground again is handled automatically.
+
+### UI events
 
 If you want to track UI related events such as full-screen state changes add the following after initializing the `BMPBitmovinPlayerView`:
 


### PR DESCRIPTION
## Description
Since the integration can't detect what happen to playback if the app is send in background, this needs to be handed by the app developer itself.
This PR will introduce a `endSession` method where the conviva tracking session can be closed. This should be called when the app enters background.

For consistency and completeness also a `initializeSession` method is added.

## Tests
- New tests for externally session management where added.