### PR TITLE
End session on destroy

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -362,6 +362,10 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         client.adEnd(sessionKey)
     }
     #endif
+
+    func onDestroy() {
+        endSession()
+    }
 }
 
 // MARK: - UserInterfaceListener

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -255,6 +255,10 @@ public final class ConvivaAnalytics: NSObject {
     }
 
     private func internalEndSession() {
+        if !isSessionActive {
+            return
+        }
+
         client.detachPlayer(sessionKey)
         client.cleanupSession(sessionKey)
         client.releasePlayerStateManager(playerStateManager)
@@ -437,7 +441,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     #endif
 
     func onDestroy() {
-        endSession()
+        internalEndSession()
     }
 }
 

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
@@ -114,4 +114,8 @@ extension BitmovinPlayerListener: PlayerListener {
         delegate?.onAdError(event)
     }
     #endif
+
+    func onDestroy(_ event: DestroyEvent) {
+        delegate?.onDestroy()
+    }
 }

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
@@ -39,4 +39,6 @@ protocol BitmovinPlayerListenerDelegate: AnyObject {
     func onAdSkipped(_ event: AdSkippedEvent)
     func onAdError(_ event: AdErrorEvent)
     #endif
+
+    func onDestroy()
 }

--- a/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
+++ b/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
@@ -150,6 +150,13 @@ class BitmovinPlayerTestDouble: BitmovinPlayer, TestDoubleDataSource {
         onPlaybackFinished(PlaybackFinishedEvent())
     }
 
+    func fakeDestroyEvent() {
+        guard let onDestroyEvent = fakeListener?.onDestroy else {
+            return
+        }
+        onDestroyEvent(DestroyEvent())
+    }
+
     override func add(listener: PlayerListener) {
         self.fakeListener = listener
     }

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -152,13 +152,12 @@ class PlayerEventsSpec: QuickSpec {
                 var spy: Spy!
                 beforeEach {
                     spy = Spy(aClass: CISClientTestDouble.self, functionName: "cleanupSession")
+                    playerDouble.fakePlayEvent()
                 }
 
                 it("on source unloaded") {
                     playerDouble.fakeSourceUnloadedEvent()
-                    DispatchQueue.main.async {
-                        expect(spy).to(haveBeenCalled())
-                    }
+                    expect(spy).toEventually(haveBeenCalled())
                 }
 
                 it("on error") {
@@ -180,6 +179,16 @@ class PlayerEventsSpec: QuickSpec {
                 it("on destroy") {
                     playerDouble.fakeDestroyEvent()
                     expect(spy).to(haveBeenCalled())
+                }
+
+                it("calls end session only if a session is active") {
+                    playerDouble.fakeSourceUnloadedEvent()
+
+                    expect(spy).toEventually(haveBeenCalled())
+                    TestHelper.shared.spyTracker.reset()
+
+                    playerDouble.fakeDestroyEvent()
+                    expect(spy).toEventuallyNot(haveBeenCalled())
                 }
 
                 describe("with on source unloaded / on error workaround") {

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -174,6 +174,11 @@ class PlayerEventsSpec: QuickSpec {
                     )
                 }
 
+                it("on destroy") {
+                    playerDouble.fakeDestroyEvent()
+                    expect(spy).to(haveBeenCalled())
+                }
+
                 describe("with on source unloaded / on error workaround") {
                     it("when on source unloaded is followed by on error") {
                         // simulating a mid stream error so simulate a session initialization first


### PR DESCRIPTION
## Description
Since the session is ended at `onSourceUnloaded` this shouldn't make an impact but just for completeness the session will also be closed `onUnload`.

## Discussion
Can we guarantee that `onSourceUnloaded` is triggered every time when a player gets destroyed? If yes we can consider just closing this PR. @jarhoax @hawk23 