### PR TITLE
Add method to report deficiencies

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -106,6 +106,28 @@ public final class ConvivaAnalytics: NSObject {
         endSession()
     }
 
+    /**
+     Sends a custom deficiency event during playback to Conviva's Player Insight. If no session is active it will NOT
+     create one.
+
+     - Parameters:
+        - message: Message which will be send to conviva
+        - severity: One of FATAL or WARNING
+        - endSession: Boolean flag if session should be closed after reporting the deficiency (Default: true)
+     */
+    public func reportPlaybackDeficiency(message: String,
+                                         severity: ErrorSeverity,
+                                         endSession: Bool = true) {
+        if !isValidSession {
+            return
+        }
+
+        client.reportError(sessionKey, errorMessage: message, errorSeverity: severity)
+        if endSession {
+            self.endSession()
+        }
+    }
+
     // MARK: - session handling
     private func setupPlayerStateManager() {
         playerStateManager = client.getPlayerStateManager()
@@ -255,8 +277,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         }
 
         let message = "\(event.code) \(event.message)"
-        client.reportError(sessionKey, errorMessage: message, errorSeverity: .ERROR_FATAL)
-        endSession()
+        reportPlaybackDeficiency(message: message, severity: .ERROR_FATAL)
     }
 
     func onMuted(_ event: MutedEvent) {

--- a/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
+++ b/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3714F23D216DD51D00B446F2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3714F23C216DD51D00B446F2 /* ViewController.swift */; };
 		3714F240216DD51D00B446F2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3714F23E216DD51D00B446F2 /* Main.storyboard */; };
 		3714F242216DD52000B446F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3714F241216DD52000B446F2 /* Assets.xcassets */; };
+		37226EC922043A9D0072DE47 /* ExternallyManagedSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37226EC822043A9D0072DE47 /* ExternallyManagedSessionTests.swift */; };
 		37756EB0216F8E0D0041806D /* TestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EAF216F8E0D0041806D /* TestDouble.swift */; };
 		37756EB2216F8E2F0041806D /* Spy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EB1216F8E2F0041806D /* Spy.swift */; };
 		37756EB4216F8E450041806D /* TestDoubleDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EB3216F8E450041806D /* TestDoubleDataSource.swift */; };
@@ -62,6 +63,7 @@
 		3714F23F216DD51D00B446F2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		3714F241216DD52000B446F2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3714F243216DD52000B446F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		37226EC822043A9D0072DE47 /* ExternallyManagedSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternallyManagedSessionTests.swift; sourceTree = "<group>"; };
 		37756EAF216F8E0D0041806D /* TestDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestDouble.swift; path = Helpers/TestDouble.swift; sourceTree = "<group>"; };
 		37756EB1216F8E2F0041806D /* Spy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Spy.swift; path = Helpers/Spy.swift; sourceTree = "<group>"; };
 		37756EB3216F8E450041806D /* TestDoubleDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestDoubleDataSource.swift; path = Helpers/TestDoubleDataSource.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				37756EBF216F9A510041806D /* ContentMetadataTests.swift */,
 				37756EC1216F9AA50041806D /* CustomEventTests.swift */,
 				607FACEB1AFB9204008FA782 /* SeekTimeshiftTests.swift */,
+				37226EC822043A9D0072DE47 /* ExternallyManagedSessionTests.swift */,
 				37756EC32170764E0041806D /* SpecHelper.swift */,
 				37EB3CD1216B70650093F085 /* TestHelper.swift */,
 				37756EAE216F8DF00041806D /* Helpers */,
@@ -707,6 +710,7 @@
 				37EB3CD3216B70D70093F085 /* TestHelper.swift in Sources */,
 				37756EB2216F8E2F0041806D /* Spy.swift in Sources */,
 				37756EBA216F8FD30041806D /* SpyTracker.swift in Sources */,
+				37226EC922043A9D0072DE47 /* ExternallyManagedSessionTests.swift in Sources */,
 				37756EB4216F8E450041806D /* TestDoubleDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/Doubles/CISClientTestDouble.swift
+++ b/Example/Tests/Doubles/CISClientTestDouble.swift
@@ -64,7 +64,8 @@ class CISClientTestDouble: NSObject, CISClientProtocol, TestDoubleDataSource {
     }
 
     func reportError(_ sessionKey: Int32, errorMessage: String!, errorSeverity severity: ErrorSeverity) {
-        spy(functionName: "reportError", args: ["errorMessage": errorMessage])
+        spy(functionName: "reportError", args: ["errorMessage": errorMessage,
+                                                "severity": "\(severity.rawValue)"])
     }
 
     func detachPlayer(_ sessionKey: Int32) {}

--- a/Example/Tests/ExternallyManagedSessionTests.swift
+++ b/Example/Tests/ExternallyManagedSessionTests.swift
@@ -1,0 +1,96 @@
+//
+//  ExternallyManagedSessionTests.swift
+//  BitmovinConvivaAnalytics_Tests
+//
+//  Created by Bitmovin on 30.01.19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Quick
+import Nimble
+import BitmovinPlayer
+import BitmovinConvivaAnalytics
+import ConvivaSDK
+
+class ExternallyManagedSessionSpec: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override func spec() {
+        var playerDouble: BitmovinPlayerTestDouble!
+
+        beforeEach {
+            playerDouble = BitmovinPlayerTestDouble()
+            TestHelper.shared.spyTracker.reset()
+            TestHelper.shared.mockTracker.reset()
+        }
+
+        context("Externally Managed Session") {
+            var convivaAnalytics: ConvivaAnalytics!
+            beforeEach {
+                do {
+                    convivaAnalytics = try ConvivaAnalytics(player: playerDouble, customerKey: "")
+                } catch {
+                    fail("ConvivaAnalytics failed with error: \(error)")
+                }
+            }
+
+            afterEach {
+                if convivaAnalytics != nil {
+                    convivaAnalytics = nil
+                }
+            }
+
+            context("report playback deficiency") {
+                var spy: Spy!
+
+                beforeEach {
+                    spy = Spy(aClass: CISClientTestDouble.self, functionName: "reportError")
+                }
+
+                it("no-opt if no session is running") {
+                    convivaAnalytics.reportPlaybackDeficiency(message: "Test", severity: .ERROR_FATAL)
+                    expect(spy).toNot(haveBeenCalled())
+                }
+
+                context("reports a deficiency") {
+                    beforeEach {
+                        playerDouble.fakePlayEvent()
+                    }
+
+                    it("reports a warning") {
+                        let severity = ErrorSeverity.ERROR_WARNING
+                        convivaAnalytics.reportPlaybackDeficiency(message: "Test", severity: .ERROR_WARNING)
+                        expect(spy).to(haveBeenCalled(withArgs: ["severity": "\(severity.rawValue)"]))
+                    }
+
+                    it("reports an error") {
+                        let severity = ErrorSeverity.ERROR_FATAL
+                        convivaAnalytics.reportPlaybackDeficiency(message: "Test", severity: .ERROR_FATAL)
+                        expect(spy).to(haveBeenCalled(withArgs: ["severity": "\(severity.rawValue)"]))
+                    }
+
+                    context("session closing handling") {
+                        beforeEach {
+                            spy = Spy(aClass: CISClientTestDouble.self, functionName: "cleanupSession")
+                        }
+                        it("closes session by default") {
+                            convivaAnalytics.reportPlaybackDeficiency(message: "Test", severity: .ERROR_FATAL)
+                            expect(spy).to(haveBeenCalled())
+                        }
+
+                        it("closes session if set to true") {
+                            convivaAnalytics.reportPlaybackDeficiency(message: "Test", severity: .ERROR_FATAL)
+                            expect(spy).to(haveBeenCalled())
+                        }
+
+                        it("not closes session if set to false") {
+                            convivaAnalytics.reportPlaybackDeficiency(message: "Test",
+                                                                      severity: .ERROR_FATAL,
+                                                                      endSession: false)
+                            expect(spy).toNot(haveBeenCalled())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Since the player does not report errors in some cases and just stalls forever this PR adds a method that the customer can then report an error if they want to.

## Tests
Tests for public method were added.