### PR TITLE
Feature/internal metadata override

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -128,7 +128,7 @@ class ContentMetadataBuilder {
             metadata.custom = newValue
         }
         get {
-            return mergeDictionaries(dict1: metadataOverrides.custom, dict2: metadata.custom)
+            return mergeDictionaries(dict1: metadata.custom, dict2: metadataOverrides.custom)
         }
     }
 

--- a/Example/Tests/ContentMetadataTests.swift
+++ b/Example/Tests/ContentMetadataTests.swift
@@ -244,12 +244,29 @@ class ContentMetadataSpec: QuickSpec {
                         expect(spy).to(haveBeenCalled(withArgs: ["streamUrl": "MyUrl"]))
                     }
 
-                    it("dont override intern custom tags") {
+                    it("override intern custom tags") {
                         metadata.custom = [
-                            "integrationVersion": "xyz"
+                            "streamType": "VOD"
                         ]
                         updateMetadataAndInitialize()
-                        expect(spy).toNot(haveBeenCalled(withArgs: ["integrationVersion": "xyz"]))
+                        expect(spy).to(haveBeenCalled(withArgs: ["streamType": "VOD"]))
+                    }
+
+                    it("add extern custom tags") {
+                        metadata.custom = [
+                            "contentType": "Episode"
+                        ]
+                        updateMetadataAndInitialize()
+                        expect(spy).to(haveBeenCalled(withArgs: ["contentType": "Episode"]))
+                    }
+
+                    it("override intern and add extern custom tags") {
+                        metadata.custom = [
+                            "streamType": "LIVE",
+                            "contentType": "Episode"
+                        ]
+                        updateMetadataAndInitialize()
+                        expect(spy).to(haveBeenCalled(withArgs: ["streamType": "LIVE", "contentType": "Episode"]))
                     }
                 }
 

--- a/Example/Tests/ContentMetadataTests.swift
+++ b/Example/Tests/ContentMetadataTests.swift
@@ -86,7 +86,7 @@ class ContentMetadataSpec: QuickSpec {
                     playerDouble.fakePlayEvent() // to initialize session
                     let spy = Spy(aClass: CISClientTestDouble.self, functionName: "createSession")
                     expect(spy).to(
-                        haveBeenCalled(withArgs: ["Custom": "Tags", "TestRun": "Success"])
+                        haveBeenCalled(withArgs: ["custom:Custom": "Tags", "custom:TestRun": "Success"])
                     )
                 }
 
@@ -223,7 +223,7 @@ class ContentMetadataSpec: QuickSpec {
                             "MyCustom": "Test Value"
                         ]
                         updateMetadataAndInitialize()
-                        expect(spy).to(haveBeenCalled(withArgs: ["MyCustom": "Test Value"]))
+                        expect(spy).to(haveBeenCalled(withArgs: ["custom:MyCustom": "Test Value"]))
                     }
 
                     it("set encoded frame rate") {
@@ -249,7 +249,7 @@ class ContentMetadataSpec: QuickSpec {
                             "streamType": "VOD"
                         ]
                         updateMetadataAndInitialize()
-                        expect(spy).to(haveBeenCalled(withArgs: ["streamType": "VOD"]))
+                        expect(spy).to(haveBeenCalled(withArgs: ["custom:streamType": "VOD"]))
                     }
 
                     it("add extern custom tags") {
@@ -257,7 +257,7 @@ class ContentMetadataSpec: QuickSpec {
                             "contentType": "Episode"
                         ]
                         updateMetadataAndInitialize()
-                        expect(spy).to(haveBeenCalled(withArgs: ["contentType": "Episode"]))
+                        expect(spy).to(haveBeenCalled(withArgs: ["custom:contentType": "Episode"]))
                     }
 
                     it("override intern and add extern custom tags") {
@@ -266,7 +266,7 @@ class ContentMetadataSpec: QuickSpec {
                             "contentType": "Episode"
                         ]
                         updateMetadataAndInitialize()
-                        expect(spy).to(haveBeenCalled(withArgs: ["streamType": "LIVE", "contentType": "Episode"]))
+                        expect(spy).to(haveBeenCalled(withArgs: ["custom:streamType": "LIVE", "custom:contentType": "Episode"]))
                     }
                 }
 

--- a/Example/Tests/Doubles/CISClientTestDouble.swift
+++ b/Example/Tests/Doubles/CISClientTestDouble.swift
@@ -92,7 +92,7 @@ class CISClientTestDouble: NSObject, CISClientProtocol, TestDoubleDataSource {
         for key in contentMetadata.custom.allKeys {
             if let keyString = key as? String {
                 if let value = contentMetadata.custom.value(forKey: keyString) as? String {
-                    args[keyString] = value
+                    args["custom:"+keyString] = value
                 }
             }
         }


### PR DESCRIPTION
Updating code to allow application to override even internal custom metadata. This gives more flexibility to application to choose whether to override the values or use defaults.

Also updated test cases to validate `MetdataOverride.custom` fields separately from other `MetdataOverride` fields.