### PR TITLE
Feature/fix for duration crash

### DIFF
--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -20,8 +20,8 @@ Conviva Analytics Integration for the Bitmovin Player iOS SDK
   s.swift_version = '4.2'
   s.cocoapods_version = '>= 1.4.0'
 
-  s.ios.dependency 'BitmovinPlayer', '~> 2.57.1'
-  s.tvos.dependency 'BitmovinPlayer', '~> 2.57.1'
+  s.ios.dependency 'BitmovinPlayer', '~> 2.57.0'
+  s.tvos.dependency 'BitmovinPlayer', '~> 2.57.0'
   s.ios.dependency 'ConvivaSDK', '~> 4.0.3'
   s.tvos.dependency 'ConvivaSDK', '~> 4.0.3'
 

--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -20,8 +20,8 @@ Conviva Analytics Integration for the Bitmovin Player iOS SDK
   s.swift_version = '4.2'
   s.cocoapods_version = '>= 1.4.0'
 
-  s.ios.dependency 'BitmovinPlayer', '~> 2.57.0'
-  s.tvos.dependency 'BitmovinPlayer', '~> 2.57.0'
+  s.ios.dependency 'BitmovinPlayer', '~> 2.57'
+  s.tvos.dependency 'BitmovinPlayer', '~> 2.57'
   s.ios.dependency 'ConvivaSDK', '~> 4.0.3'
   s.tvos.dependency 'ConvivaSDK', '~> 4.0.3'
 

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -324,7 +324,7 @@ public final class ConvivaAnalytics: NSObject {
     }
 
     private func buildDynamicContentMetadata() {
-        if !player.isLive {
+        if !player.isLive && player.duration.isFinite {
             contentMetadataBuilder.duration = Int(player.duration)
         }
         contentMetadataBuilder.streamType = player.isLive ? .CONVIVA_STREAM_LIVE : .CONVIVA_STREAM_VOD


### PR DESCRIPTION
**Issue**
 
If Chromecast is connected before playback starts and auto play is enabled, the `onPlay` event is fired before the casting playback is started and duration is available in remote player. Conviva analytics integration listens to `onPlay` event and tries to fetch the duration which comes out to be NaN in this case and typecasting it causes a crash in this scenario.

**Fix**

Check is the `duration` value is finite before using it. Just preventing the crash by putting check there is sufficient and the value of duration gets updated correctly subsequently.

Additionally updated the Bitmovin player dependency in Podspec to `2.57` to allow all 2.x player versions > 2.57.0