### PR TITLE
Fix failing tests around stalling/buffering

### DIFF
--- a/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
+++ b/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
@@ -373,7 +373,6 @@
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = 7UXPEM3WRB;
 						LastSwiftMigration = 1000;
-						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
 			};
@@ -952,7 +951,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BitmovinConvivaAnalytics_Example.app/BitmovinConvivaAnalytics_Example";
 			};
 			name = Debug;
 		};
@@ -970,7 +968,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BitmovinConvivaAnalytics_Example.app/BitmovinConvivaAnalytics_Example";
 			};
 			name = Release;
 		};

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BitmovinConvivaAnalytics (1.3.1):
+  - BitmovinConvivaAnalytics (1.4.0):
     - BitmovinPlayer (~> 2.57)
     - ConvivaSDK (~> 4.0)
   - BitmovinPlayer (2.64.0)
@@ -39,7 +39,7 @@ CHECKOUT OPTIONS:
     :tag: 2.64.0
 
 SPEC CHECKSUMS:
-  BitmovinConvivaAnalytics: 3229ffbf105f5e80a947bb569f1a679b967990f8
+  BitmovinConvivaAnalytics: f9fb3295fa721fce23f276c870beb79277675e49
   BitmovinPlayer: 9696532ec0ac122a28782c9072ad16130f6d4f32
   ConvivaSDK: 877abbdc0b2b77dcad4b709b03c2cd8a900a4e46
   GoogleAds-IMA-iOS-SDK: 3c01b8db7d01de6b4a3b1d58744d4bc426a2d821

--- a/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
+++ b/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
@@ -15,7 +15,9 @@ class BitmovinPlayerTestDouble: BitmovinPlayer, TestDoubleDataSource {
     var fakeListener: PlayerListener?
 
     override init() {
-        super.init(configuration: PlayerConfiguration())
+        let config = PlayerConfiguration()
+        config.key = "foobar"
+        super.init(configuration: config)
     }
 
     func fakeReadyEvent() {

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -26,8 +26,15 @@ class PlayerEventsSpec: QuickSpec {
         context("player event handling") {
             var convivaAnalytics: ConvivaAnalytics!
             beforeEach {
+                let convivaConfig = ConvivaConfiguration()
+                convivaConfig.debugLoggingEnabled = true
+
                 do {
-                    convivaAnalytics = try ConvivaAnalytics(player: playerDouble, customerKey: "")
+                    convivaAnalytics = try ConvivaAnalytics(
+                        player: playerDouble,
+                        customerKey: "",
+                        config: convivaConfig
+                    )
                 } catch {
                     fail("ConvivaAnalytics failed with error: \(error)")
                 }

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -134,6 +134,7 @@ class PlayerEventsSpec: QuickSpec {
 
                 context("after stalling") {
                     beforeEach {
+                        playerDouble.fakePlayingEvent()
                         playerDouble.fakeStallStartedEvent()
                     }
 


### PR DESCRIPTION
### Problem
Some test cases in `devlop` failed.

### Solution
Buffering is only reported to Conviva once playback was started, but the tests were not adapted to that. Emitting the `playing` event before the stall event resolved the problem.

### Notes
- I enabled the debug logs of the integration to make it easier to troubleshoot should tests fail in the future.
- Also removed the example app as host. Tests run now without adding a specific license key and a bit faster.