### PR TITLE
adding fix to control if Session is active before changing playback s…

### DIFF
--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'BitmovinConvivaAnalytics'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'Conviva Analytics Integration for the Bitmovin Player iOS SDK'
 
   s.description      = <<-DESC

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -343,7 +343,7 @@ public final class ConvivaAnalytics: NSObject {
 
     private func onPlaybackStateChanged(playerState: PlayerState) {
         // do not report any playback state changes while player isStalled except buffering
-        if isStalled && playerState != .CONVIVA_BUFFERING {
+        if !isSessionActive || isStalled && playerState != .CONVIVA_BUFFERING {
             return
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.1]
+### Fixed
+
+- Exception when casting to Chromecast.
+
 ## [2.0.0]
 
 ### Added


### PR DESCRIPTION


### Problem
Customer reported an exception happening when trying to cast to Chromecast.
Debugging showed this issue happens because of an attempt of Conviva to update the playback status when there was no session created.

### Solution
A simple check for an existing session before attempting to update the player status prevents the exception to happen

### Notes


### Checklist
- [X ] I added an update to `CHANGELOG.md` file
- [ ] I ran all the tests in the project and they succeed
