### PR TITLE
Bug fix/stalling event

### DIFF
--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'BitmovinConvivaAnalytics'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'Conviva Analytics Integration for the Bitmovin Player iOS SDK'
 
   s.description      = <<-DESC

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -346,6 +346,13 @@ public final class ConvivaAnalytics: NSObject {
         if isStalled && playerState != .CONVIVA_BUFFERING {
             return
         }
+        // do not report any stalling when isStalled false (StallEnded trigered immediatelly after StallStarted)
+        else if !isStalled && playerState == .CONVIVA_BUFFERING {
+            self.logger.debugLog(
+                message: "[ ConvivaAnalytics ] false stalling, not registering to Conviva"
+            )
+            return;
+        }
 
         playerStateManager.setPlayerState!(playerState)
         logger.debugLog(message: "Player state changed: \(playerState.rawValue)")
@@ -416,7 +423,12 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
 
     func onStallStarted() {
         isStalled = true
-        onPlaybackStateChanged(playerState: .CONVIVA_BUFFERING)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+            self.logger.debugLog(
+                message: "[ ConvivaAnalytics ] calling StallStarted after 100 milliseconds"
+            )
+             self.onPlaybackStateChanged(playerState: .CONVIVA_BUFFERING)
+             }
     }
 
     func onStallEnded() {

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -425,7 +425,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         isStalled = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
             self.logger.debugLog(
-                message: "[ ConvivaAnalytics ] calling StallStarted after 100 milliseconds"
+                message: "[ ConvivaAnalytics ] calling StallStarted after 0.10 seconds"
             )
              self.onPlaybackStateChanged(playerState: .CONVIVA_BUFFERING)
              }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## [2.0.1]
+
+### Fixed
+
+- Stall events being over reported
 
 ## [2.0.0]
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 def shared_pods
   pod 'BitmovinConvivaAnalytics', path: '../'
-  pod 'BitmovinPlayer', '3.6.1'
+  pod 'BitmovinPlayer', '3.11.0'
   pod 'ConvivaSDK', '4.0.13'
 
   pod 'SwiftLint'

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -129,12 +129,19 @@ class PlayerEventsSpec: QuickSpec {
                         haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_PAUSED.rawValue)"])
                     )
                 }
-
                 it("on stall started") {
                     playerDouble.fakeStallStartedEvent()
-                    expect(spy).to(
-                        haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_BUFFERING.rawValue)"])
-                    )
+                        expect(spy).toEventuallyNot(
+                            haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_BUFFERING.rawValue)"])
+                        )
+                }
+                it("on stall started") {
+                    playerDouble.fakeStallStartedEvent()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        expect(spy).to(
+                            haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_BUFFERING.rawValue)"])
+                        )
+                    }
                 }
 
                 context("after stalling") {

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -129,11 +129,33 @@ class PlayerEventsSpec: QuickSpec {
                         haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_PAUSED.rawValue)"])
                     )
                 }
-                it("on stall started") {
+                it("on stall started/ Stall Ended wait 0.10 seconds") {
+                    playerDouble.fakePlayingEvent()
                     playerDouble.fakeStallStartedEvent()
-                        expect(spy).toEventuallyNot(
+                    playerDouble.fakeStallEndedEvent()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        expect(spy).notTo(
                             haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_BUFFERING.rawValue)"])
                         )
+                    }
+                }
+                it("on stall started/Stall Ended no wait") {
+                    playerDouble.fakePlayingEvent()
+                    playerDouble.fakeStallStartedEvent()
+                    playerDouble.fakeStallEndedEvent()
+                    expect(spy).toEventuallyNot(
+                            haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_BUFFERING.rawValue)"])
+                        )
+                }
+                it("on stall started / Stall Ended after 0.10 seconds") {
+                    playerDouble.fakePlayingEvent()
+                    playerDouble.fakeStallStartedEvent()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        playerDouble.fakeStallEndedEvent()
+                    }
+                    expect(spy).to(
+                        haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_PLAYING.rawValue)"])
+                    )
                 }
                 it("on stall started") {
                     playerDouble.fakeStallStartedEvent()

--- a/Example/Tests/PlayerEventTests.swift
+++ b/Example/Tests/PlayerEventTests.swift
@@ -152,10 +152,11 @@ class PlayerEventsSpec: QuickSpec {
                     playerDouble.fakeStallStartedEvent()
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
                         playerDouble.fakeStallEndedEvent()
+                        expect(spy).to(
+                            haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_BUFFERING.rawValue)"])
+                        )
                     }
-                    expect(spy).to(
-                        haveBeenCalled(withArgs: ["newState": "\(PlayerState.CONVIVA_PLAYING.rawValue)"])
-                    )
+                    
                 }
                 it("on stall started") {
                     playerDouble.fakeStallStartedEvent()


### PR DESCRIPTION
### Problem
With SDK v3 there is an identified issue that causes the trigger of a `Stallstarted/Stallended` event after every `Play event`. This causes the Conviva integration to register "false Stalling" events and altering the correct reporting of the playback.

### Solution
As per Suggestion from Engineering, the solution was to add a delay on the report of StallStarted event (0,10 seconds). So if a "false" `StallStarted` event triggers, the expectation is that a `StallEnded` event will trigger right after that, setting the `isStalling` flag to `false` and avoiding the register of the stalling to Conviva.
### Notes
Real Stalling situations within the range of 0.10 seconds won't be registered.

### Checklist
- [x ] I added an update to `CHANGELOG.md` file
- [x ] I ran all the tests in the project and they succeed
