### PR TITLE
adding logs for session creation and updates

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -28,7 +28,7 @@ public struct MetadataOverrides {
     public init() {}
 }
 
-class ContentMetadataBuilder {
+class ContentMetadataBuilder : CustomStringConvertible {
     let logger: Logger
     var contentMetadata: CISContentMetadata
 
@@ -37,6 +37,16 @@ class ContentMetadataBuilder {
     var metadata: MetadataOverrides = MetadataOverrides()
     var playbackStarted: Bool = false
 
+    var description: String {
+        return """
+        <\(type(of: self)): \
+        contentMetadata = \(contentMetadata) \
+        metadata = \(metadata) \
+        metadataOverrieds = \(metadataOverrides) \
+        playbackStarted = \(playbackStarted)>
+        """
+    }
+    
     init(logger: Logger) {
         self.logger = logger
         contentMetadata = CISContentMetadata()

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -274,6 +274,7 @@ public final class ConvivaAnalytics: NSObject {
 
         setupPlayerStateManager()
         updateSession()
+        logger.debugLog(message: "Creating session \(sessionKey) with metadata: \(contentMetadataBuilder)")
 
         client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
         logger.debugLog(message: "Session started")
@@ -292,7 +293,8 @@ public final class ConvivaAnalytics: NSObject {
             playerStateManager.setVideoResolutionWidth!(videoQuality.width)
             playerStateManager.setVideoResolutionHeight!(videoQuality.height)
         }
-
+        
+        logger.debugLog(message: "Updating session \(sessionKey) with metadata: \(contentMetadataBuilder)")
         client.updateContentMetadata(sessionKey, metadata: contentMetadataBuilder.build())
     }
 
@@ -301,6 +303,7 @@ public final class ConvivaAnalytics: NSObject {
             return
         }
 
+        logger.debugLog(message: "Ending session \(sessionKey)")
         client.detachPlayer(sessionKey)
         client.cleanupSession(sessionKey)
         playerStateManager.reset?()


### PR DESCRIPTION
### Problem
One customer reported some issues related to ghost sessions where `updateContentMetadata` is not being called. 

### Solution
This commit added some logs to help them narrow down the problem.

### Notes
It is merged into develop branch.

