### PR TITLE
Report play head time on every time change update

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -365,6 +365,15 @@ public final class ConvivaAnalytics: NSObject {
         videoAnalytics.reportPlaybackMetric(CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE, value: playerState.rawValue)
         logger.debugLog(message: "Player state changed: \(playerState.rawValue)")
     }
+    
+    private func reportPlayHeadTime() {
+        guard isSessionActive else { return }
+        
+        videoAnalytics.reportPlaybackMetric(
+            CIS_SSDK_PLAYBACK_METRIC_PLAY_HEAD_TIME,
+            value: Int64(player.currentTime(.relativeTime) * 1000)
+        )
+    }
 }
 
 // MARK: - PlayerListener
@@ -378,6 +387,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     }
 
     func onTimeChanged() {
+        reportPlayHeadTime()
         updateSession()
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - iOS/tvOS 12 and 13 support
+
+### Added
+- Hook into `onTimeChanged` callback for reporting Play head time (PHT) to Conviva playback metric. 
+
 ## [3.0.1]
 
 ### Fixed

--- a/Example/Tests/Helpers/CustomNimbleMatchers.swift
+++ b/Example/Tests/Helpers/CustomNimbleMatchers.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Nimble
 
-public func haveBeenCalled<T>(withArgs: [String: String]? = nil) -> Predicate<T> {
+public func haveBeenCalled<T>(withArgs: [String: String]? = nil) -> Nimble.Predicate<T> {
     return Predicate { (actualExpression: Expression<T>) throws -> PredicateResult in
 
         if let functionName = (try? actualExpression.evaluate() as? Spy)??.functionName {


### PR DESCRIPTION
### Problem
A new value that is needed in Conviva to get a pass on validation is the play head time (PHT). This can be useful for example in error reporting, to know in what second the user has an issue.

### Solution
Hook into the `onTimeChanged()` delegate call to report the PHT

### Notes
`.relativeTime` returns the correct value for both `live` and `vod` streams, which is the relative progress in seconds taken from start of the stream, as per Conviva request.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed

At first I got a `'Predicate' is ambiguous for type lookup in this context`-error in the example-project. After adding a specific `Nimble.` identifier the tests succeeded.
