### PR TITLE
Increase minimum player version

### DIFF
--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -20,8 +20,8 @@ Conviva Analytics Integration for the Bitmovin Player iOS SDK
   s.swift_version = '5.0'
   s.cocoapods_version = '>= 1.9.0'
 
-  s.ios.dependency 'BitmovinPlayer', '~> 3.0'
-  s.tvos.dependency 'BitmovinPlayer', '~> 3.0'
+  s.ios.dependency 'BitmovinPlayer', '~> 3.63'
+  s.tvos.dependency 'BitmovinPlayer', '~> 3.63'
   s.ios.dependency 'ConvivaSDK', '~> 4.0'
   s.tvos.dependency 'ConvivaSDK', '~> 4.0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- Updated minimum Bitmovin Player version to 3.62.0 and raised minimum deployment targets to iOS/tvOS 14.0
+- Raised minimum deployment targets to iOS/tvOS 14.0
+- Updated minimum Bitmovin Player version to 3.63.0
 
 ### Removed
 - iOS/tvOS 12 and 13 support


### PR DESCRIPTION
### Problem
The latest (unreleased) changelog contains that the minimum Bitmovin Player version was raised, but the podspec file did not reflect that.

### Solution
Raise the required Bitmovin Player versions

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
