### PR TITLE
Support additional device content tags in conviva integration

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -19,12 +19,10 @@ public struct MetadataOverrides {
     public var applicationName: String?
     public var custom: [String: Any]?
     public var duration: Int?
-    // swiftlint:disable line_length
-     /// Standard Conviva tags that aren't covered by the other fields in this class.
-     /// List of tags can be found here:
-     /// [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
+    /// Standard Conviva tags that aren't covered by the other fields in this class.
+    /// List of tags can be found here:
+    /// [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
     public var additionalStandardTags: [String: Any]?
-    // swiftlint:enable line_length
 
     // Dynamic
     public var encodedFramerate: Int?

--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -20,11 +20,9 @@ public struct MetadataOverrides {
     public var custom: [String: Any]?
     public var duration: Int?
     // swiftlint:disable line_length
-    /**
-     Standard Conviva tags that aren't covered by the other fields in this class.
-     List of tags can be found here:
-     [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
-     */
+     /// Standard Conviva tags that aren't covered by the other fields in this class.
+     /// List of tags can be found here:
+     /// [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
     public var additionalStandardTags: [String: Any]?
     // swiftlint:enable line_length
 

--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -19,10 +19,12 @@ public struct MetadataOverrides {
     public var applicationName: String?
     public var custom: [String: Any]?
     public var duration: Int?
+    // swiftlint:disable line_length
     /// Standard Conviva tags that aren't covered by the other fields in this class.
     /// List of tags can be found here:
     /// [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
     public var additionalStandardTags: [String: Any]?
+    // swiftlint:enable line_length
 
     // Dynamic
     public var encodedFramerate: Int?

--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -19,6 +19,14 @@ public struct MetadataOverrides {
     public var applicationName: String?
     public var custom: [String: Any]?
     public var duration: Int?
+    // swiftlint:disable line_length
+    /**
+     Standard Conviva tags that aren't covered by the other fields in this class.
+     List of tags can be found here:
+     [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
+     */
+    public var additionalStandardTags: [String: Any]?
+    // swiftlint:enable line_length
 
     // Dynamic
     public var encodedFramerate: Int?
@@ -84,6 +92,9 @@ class ContentMetadataBuilder: CustomStringConvertible {
             }
             if let custom = self.custom {
                 contentInfo.merge(custom) { $1 }
+            }
+            if let additionalStandardTags = self.additionalStandardTags {
+                contentInfo.merge(additionalStandardTags) { $1 }
             }
         } else {
             if let duration = self.duration, duration > 0 {
@@ -157,6 +168,15 @@ class ContentMetadataBuilder: CustomStringConvertible {
         }
         set {
             metadata.duration = newValue
+        }
+    }
+
+    var additionalStandardTags: [String: Any]? {
+        get {
+            mergeDictionaries(dict1: metadata.additionalStandardTags, dict2: metadataOverrides.additionalStandardTags)
+        }
+        set {
+            metadata.additionalStandardTags = newValue
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Ad tracking support on tvOS
 - The IMA SDK and sample ads to the tvOS sample app
+- New `MetadataOverrides.additionalStandardTags` that allows to set additional standard tags for the session. The List of tags can be found here: [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
 
 ### Internal
 - Added a Gemfile to pin the CocoaPods version to 1.15.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Ad tracking support on tvOS
 - The IMA SDK and sample ads to the tvOS sample app
-- New `MetadataOverrides.additionalStandardTags` that allows to set additional standard tags for the session. The List of tags can be found here: [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
+- `MetadataOverrides.additionalStandardTags` that allows to set additional standard tags for the session. The List of tags can be found here: [Pre-defined Video and Content Metadata](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)
 
 ### Internal
 - Added a Gemfile to pin the CocoaPods version to 1.15.2

--- a/Example/BitmovinConvivaAnalytics/ViewController.swift
+++ b/Example/BitmovinConvivaAnalytics/ViewController.swift
@@ -64,7 +64,8 @@ class ViewController: UIViewController {
         var metadata = MetadataOverrides()
         metadata.applicationName = "Bitmovin iOS Conviva integration example app"
         metadata.viewerId = "awesomeViewerId"
-        metadata.custom = ["contentType": "Episode"]
+        metadata.custom = ["custom_tag": "Episode"]
+        metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
 
         do {
             convivaAnalytics = try ConvivaAnalytics(

--- a/Example/BitmovinConvivaAnalyticsTvOSExample/ViewController.swift
+++ b/Example/BitmovinConvivaAnalyticsTvOSExample/ViewController.swift
@@ -59,7 +59,8 @@ class ViewController: UIViewController {
         var metadata = MetadataOverrides()
         metadata.applicationName = "Bitmovin tvOS Conviva integration example app"
         metadata.viewerId = "awesomeViewerId"
-        metadata.custom = ["contentType": "Episode"]
+        metadata.custom = ["custom_tag": "Episode"]
+        metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
 
         do {
             convivaAnalytics = try ConvivaAnalytics(

--- a/Example/Tests/CISVideoAnalyticsTestDouble.swift
+++ b/Example/Tests/CISVideoAnalyticsTestDouble.swift
@@ -42,7 +42,8 @@ class CISVideoAnalyticsTestDouble: NSObject, CISVideoAnalyticsProtocol, TestDoub
             "encodedFrameRate": "\(contentInfo?[CIS_SSDK_METADATA_ENCODED_FRAMERATE] ?? "")",
             "contentType": "\(contentInfo?["contentType"] ?? "")",
             "MyCustom": "\(contentInfo?["MyCustom"] ?? "")",
-            "streamType": "\(contentInfo?["streamType"] ?? "")"
+            "streamType": "\(contentInfo?["streamType"] ?? "")",
+            "AdditionalStandardTag": "\(contentInfo?["AdditionalStandardTag"] ?? "")"
         ])
     }
 

--- a/Example/Tests/ContentMetadataTest.swift
+++ b/Example/Tests/ContentMetadataTest.swift
@@ -236,13 +236,21 @@ class ContentMetadataTest: QuickSpec {
                         expect(spy).to(haveBeenCalled(withArgs: ["MyCustom": "Test Value"]))
                     }
 
+                    it("set additionalStandardTags") {
+                        metadata.additionalStandardTags = [
+                            "AdditionalStandardTag": "VOD"
+                        ]
+                        updateMetadataAndInitialize()
+                        expect(spy).to(haveBeenCalled(withArgs: ["AdditionalStandardTag": "VOD"]))
+                    }
+
                     it("set encoded framerate") {
                          metadata.encodedFramerate = 55
                          updateMetadataAndInitialize()
                          expect(spy).to(haveBeenCalled(withArgs: ["encodedFrameRate": "55"]))
                     }
 
-                    it("set default resrouce") {
+                    it("set default resource") {
                         metadata.defaultResource = "MyResource"
                         updateMetadataAndInitialize()
                         expect(spy).to(haveBeenCalled(withArgs: ["defaultResource": "MyResource"]))
@@ -345,6 +353,14 @@ class ContentMetadataTest: QuickSpec {
                         ]
                         updateMetadataAndInitialize()
                         expect(spy).toNot(haveBeenCalled(withArgs: ["MyCustom": "Test Value"]))
+                    }
+
+                    it("set additionalStandardTags") {
+                        metadata.additionalStandardTags = [
+                            "AdditionalStandardTag": "VOD"
+                        ]
+                        updateMetadataAndInitialize()
+                        expect(spy).toNot(haveBeenCalled(withArgs: ["AdditionalStandardTag": "VOD"]))
                     }
 
                     it("set default resource") {

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ Details about usage of `BitmovinPlayer` can be found [here](https://github.com/b
 
 ### Content Metadata handling
 
-If you want to override some content metadata attributes you can do so by adding the following:
+If you want to override some content metadata attributes or track additional custom or standard tags you can do so by adding the following:
 
 ```swift
 var metadata = BitmovinConvivaAnalytics.Metadata()
 metadata.applicationName = "Bitmovin iOS Conviva integration example app"
 metadata.viewerId = "awesomeViewerId"
-metadata.custom = ["contentType": "Episode"]
+metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
+metadata.custom = ["custom_tag": "value"]
 
 // …
 // Initialize ConvivaAnalytics


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
Conviva has a list of [predefined standard device and content tags ](https://pulse.conviva.com/learning-center/content/sensor_developer_center/sensor_integration/ios/ios_stream_sensor.html#Predefined_video_meta)that this integration currently doesn't support reporting.

### Solution
- Add `MetadataOverrides.additionalStandardTags` that allows to set additional standard tags for the session.
- Update the readme and example app

### Notes
<!-- Anything worth pointing out -->
Android integration PR: https://github.com/bitmovin/bitmovin-player-android-analytics-conviva/pull/56

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
