### PR TITLE
Ad lifecycle reporting

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -562,15 +562,10 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     }
 
     func onAdBreakStarted(_ event: AdBreakStartedEvent) {
-        var adAttributes = [String: Any]()
-        adAttributes["c3.ad.position"] = AdEventUtil.parseAdPosition(
-            event: event,
-            contentDuration: player.duration
-        ).rawValue
         videoAnalytics.reportAdBreakStarted(
             AdPlayer.ADPLAYER_CONTENT,
             adType: AdTechnology.CLIENT_SIDE,
-            adBreakInfo: adAttributes
+            adBreakInfo: [AnyHashable: Any]()
         )
     }
 

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -555,10 +555,12 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
 
     func onAdSkipped(_ event: AdSkippedEvent) {
         adAnalytics.reportAdSkipped()
+        customEvent(event: event)
     }
 
     func onAdError(_ event: AdErrorEvent) {
         adAnalytics.reportAdFailed(event.message, adInfo: nil)
+        customEvent(event: event)
     }
 
     func onAdBreakStarted(_ event: AdBreakStartedEvent) {
@@ -567,10 +569,12 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
             adType: AdTechnology.CLIENT_SIDE,
             adBreakInfo: [AnyHashable: Any]()
         )
+        customEvent(event: event)
     }
 
     func onAdBreakFinished(_ event: AdBreakFinishedEvent) {
         videoAnalytics.reportAdBreakEnded()
+        customEvent(event: event)
     }
 
     func onDestroy() {

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -20,6 +20,7 @@ public final class ConvivaAnalytics: NSObject {
     let config: ConvivaConfiguration
     let analytics: CISAnalytics
     let videoAnalytics: CISVideoAnalytics
+    let adAnalytics: CISAdAnalytics
     let contentMetadataBuilder: ContentMetadataBuilder
     var isSessionActive = false
     var isBumper = false
@@ -88,6 +89,7 @@ public final class ConvivaAnalytics: NSObject {
         self.contentMetadataBuilder = ContentMetadataBuilder(logger: logger)
 
         videoAnalytics = analytics.createVideoAnalytics()
+        adAnalytics = analytics.createAdAnalytics()
         super.init()
 
         listener = BitmovinPlayerListener(player: player)
@@ -194,6 +196,7 @@ public final class ConvivaAnalytics: NSObject {
 
     public func release() {
         videoAnalytics.cleanup()
+        adAnalytics.cleanup()
         analytics.cleanup()
     }
     /**

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -510,15 +510,37 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         }
         videoAnalytics.reportPlaybackMetric(CIS_SSDK_PLAYBACK_METRIC_SEEK_ENDED, value: Int64(-1))
     }
-
+    
     // MARK: - Ad events
     func onAdStarted(_ event: AdStartedEvent) {
         let adPosition: ConvivaSDK.AdPosition = AdEventUtil.parseAdPosition(
             event: event,
             contentDuration: player.duration
         )
+        var adInfo = [String: Any]()
+        adInfo["c3.ad.position"] = adPosition.rawValue
+        adAnalytics.reportAdLoaded(adInfo)
+        adAnalytics.reportAdStarted(adInfo)
+    }
+
+    func onAdFinished() {
+        adAnalytics.reportAdEnded()
+    }
+
+    func onAdSkipped(_ event: AdSkippedEvent) {
+        adAnalytics.reportAdSkipped()
+    }
+
+    func onAdError(_ event: AdErrorEvent) {
+        adAnalytics.reportAdFailed(event.message, adInfo: nil)
+    }
+
+    func onAdBreakStarted(_ event: AdBreakStartedEvent) {
         var adAttributes = [String: Any]()
-        adAttributes["c3.ad.position"] = adPosition.rawValue
+        adAttributes["c3.ad.position"] = AdEventUtil.parseAdPosition(
+            event:event,
+            contentDuration: player.duration
+        ).rawValue
         videoAnalytics.reportAdBreakStarted(
             AdPlayer.ADPLAYER_CONTENT,
             adType: AdTechnology.CLIENT_SIDE,
@@ -526,26 +548,8 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         )
     }
 
-    func onAdFinished() {
-        videoAnalytics.reportAdBreakEnded()
-    }
-
-    func onAdSkipped(_ event: AdSkippedEvent) {
-        customEvent(event: event)
-        videoAnalytics.reportAdBreakEnded()
-    }
-
-    func onAdError(_ event: AdErrorEvent) {
-        customEvent(event: event)
-        videoAnalytics.reportAdBreakEnded()
-    }
-
-    func onAdBreakStarted(_ event: AdBreakStartedEvent) {
-        customEvent(event: event)
-    }
-
     func onAdBreakFinished(_ event: AdBreakFinishedEvent) {
-        customEvent(event: event)
+        videoAnalytics.reportAdBreakEnded()
     }
 
     func onDestroy() {

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -385,19 +385,21 @@ public final class ConvivaAnalytics: NSObject {
             value: Int64(player.currentTime(.relativeTime) * 1_000)
         )
     }
+}
 
-    private func adToAdInfo(ad: Ad) -> [String: Any] {
+private extension Ad {
+    var adInfo: [String: Any] {
         var adInfo = [String: Any]()
         adInfo["c3.ad.technology"] = "Client Side"
 
-        if ad.mediaFileUrl != nil {
-            adInfo[CIS_SSDK_METADATA_STREAM_URL] = ad.mediaFileUrl
+        if mediaFileUrl != nil {
+            adInfo[CIS_SSDK_METADATA_STREAM_URL] = mediaFileUrl
         }
-        if ad.identifier != nil {
-            adInfo["c3.ad.id"] = ad.identifier
+        if identifier != nil {
+            adInfo["c3.ad.id"] = identifier
         }
 
-        let vastAdData = ad.data as? VastAdData
+        let vastAdData = data as? VastAdData
         if vastAdData?.adTitle != nil {
             adInfo[CIS_SSDK_METADATA_ASSET_NAME] = vastAdData?.adTitle
         }
@@ -532,7 +534,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
 
     // MARK: - Ad events
     func onAdStarted(_ event: AdStartedEvent) {
-        var adInfo = adToAdInfo(ad: event.ad)
+        var adInfo = event.ad.adInfo
         let adPosition: ConvivaSDK.AdPosition = AdEventUtil.parseAdPosition(
             event: event,
             contentDuration: player.duration

--- a/BitmovinConvivaAnalytics/Classes/Helper/AdEventUtil.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/AdEventUtil.swift
@@ -13,18 +13,6 @@ import Foundation
 enum AdEventUtil {
     static let positionRegexPattern = "pre|post|[0-9]+%|([0-9]+:)?([0-9]+:)?[0-9]+(\\.[0-9]+)?"
 
-    static func parseAdPosition(event: AdBreakStartedEvent, contentDuration: TimeInterval) -> ConvivaSDK.AdPosition {
-        let position = event.adBreak.scheduleTime
-
-        return if position == 0.0 {
-             .ADPOSITION_PREROLL
-        } else if position == contentDuration {
-             .ADPOSITION_POSTROLL
-        } else {
-            .ADPOSITION_MIDROLL
-        }
-    }
-
     static func parseAdPosition(event: AdStartedEvent, contentDuration: TimeInterval) -> ConvivaSDK.AdPosition {
         guard let position = event.position else {
             return .ADPOSITION_PREROLL

--- a/BitmovinConvivaAnalytics/Classes/Helper/AdEventUtil.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/AdEventUtil.swift
@@ -13,6 +13,18 @@ import Foundation
 enum AdEventUtil {
     static let positionRegexPattern = "pre|post|[0-9]+%|([0-9]+:)?([0-9]+:)?[0-9]+(\\.[0-9]+)?"
 
+    static func parseAdPosition(event: AdBreakStartedEvent, contentDuration: TimeInterval) -> ConvivaSDK.AdPosition {
+        let position = event.adBreak.scheduleTime
+
+        return if position == 0.0 {
+             .ADPOSITION_PREROLL
+        } else if position == contentDuration {
+             .ADPOSITION_POSTROLL
+        } else {
+            .ADPOSITION_MIDROLL
+        }
+    }
+    
     static func parseAdPosition(event: AdStartedEvent, contentDuration: TimeInterval) -> ConvivaSDK.AdPosition {
         guard let position = event.position else {
             return .ADPOSITION_PREROLL

--- a/BitmovinConvivaAnalytics/Classes/Helper/AdEventUtil.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/AdEventUtil.swift
@@ -24,7 +24,7 @@ enum AdEventUtil {
             .ADPOSITION_MIDROLL
         }
     }
-    
+
     static func parseAdPosition(event: AdStartedEvent, contentDuration: TimeInterval) -> ConvivaSDK.AdPosition {
         guard let position = event.position else {
             return .ADPOSITION_PREROLL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Ad break started and ended is now reported with `AdBreakStartedEvent` and `AdBreakFinishedEvent`
 
-### Removed
-- Custom event for `AdSkippedEvent` and `AdErrorEvent`. Replaced by Conviva build in tracking
-
 ### Internal
 - Added a Gemfile to pin the CocoaPods version to 1.15.2
 - Added a Github Actions workflow to validate code style using SwiftLint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Ad analytics for ad event reporting
 - Ad tracking support on tvOS
 - The IMA SDK and sample ads to the tvOS sample app
+
+### Changed
+- Ad break started and ended is now reported with `AdBreakStartedEvent` and `AdBreakFinishedEvent`
+
+### Removed
+- Custom event for `AdSkippedEvent` and `AdErrorEvent`. Replaced by Conviva build in tracking
 
 ### Internal
 - Added a Gemfile to pin the CocoaPods version to 1.15.2

--- a/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
+++ b/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
@@ -103,6 +103,30 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
         )
     }
 
+    func fakeAdBreakStartedEvent(position: Double = 0.0) {
+        guard let onAdBreakStarted = fakeListener?.onAdBreakStarted else {
+            return
+        }
+        onAdBreakStarted(
+            AdBreakStartedEvent(
+                adBreak: TestAdBreak(position: position)
+            ),
+            player
+        )
+    }
+
+    func fakeAdBreakFinishedEvent(position: Double = 0.0) {
+        guard let onAdBreakFinished = fakeListener?.onAdBreakFinished else {
+            return
+        }
+        onAdBreakFinished(
+            AdBreakFinishedEvent(
+                adBreak: TestAdBreak(position: position)
+            ),
+            player
+        )
+    }
+
     func fakeTimeChangedEvent() {
         guard let onTimeChanged = fakeListener?.onTimeChanged else {
             return
@@ -248,6 +272,47 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
             return mockedValue as! TimeInterval
         }
         return player.currentTime
+    }
+}
+
+class TestAdBreak: NSObject, AdBreak {
+    var identifier: String
+    var scheduleTime: TimeInterval
+    var ads: [any Ad]
+    var totalNumberOfAds: UInt
+    var replaceContentDuration: TimeInterval
+
+    convenience init(position: Double) {
+        self.init(scheduleTime: TimeInterval(floatLiteral: position))
+    }
+
+    init(
+        identifier: String = "testAdbreak",
+        scheduleTime: TimeInterval = TimeInterval(floatLiteral: 0.0),
+        ads: [any Ad] = [any Ad](),
+        totalNumberOfAds: UInt = 0,
+        replaceContentDuration: TimeInterval = TimeInterval(floatLiteral: 0.0)
+    ) {
+        self.identifier = identifier
+        self.scheduleTime = scheduleTime
+        self.ads = ads
+        self.totalNumberOfAds = totalNumberOfAds
+        self.replaceContentDuration = replaceContentDuration
+    }
+
+    func register(_ adItem: any Ad) {
+        ads.append(adItem)
+        totalNumberOfAds = UInt(ads.count)
+    }
+
+    // swiftlint:disable:next identifier_name unavailable_function
+    func _toJsonString() throws -> String {
+        fatalError("Not Implemented")
+    }
+
+    // swiftlint:disable:next identifier_name unavailable_function
+    func _toJsonData() -> [AnyHashable: Any] {
+        fatalError("Not Implemented")
     }
 }
 

--- a/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
+++ b/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
@@ -278,7 +278,7 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
 class TestAdBreak: NSObject, AdBreak {
     var identifier: String
     var scheduleTime: TimeInterval
-    var ads: [any Ad]
+    var ads: [Ad]
     var totalNumberOfAds: UInt
     var replaceContentDuration: TimeInterval
 
@@ -289,7 +289,7 @@ class TestAdBreak: NSObject, AdBreak {
     init(
         identifier: String = "testAdbreak",
         scheduleTime: TimeInterval = TimeInterval(floatLiteral: 0.0),
-        ads: [any Ad] = [any Ad](),
+        ads: [Ad] = [Ad](),
         totalNumberOfAds: UInt = 0,
         replaceContentDuration: TimeInterval = TimeInterval(floatLiteral: 0.0)
     ) {
@@ -300,7 +300,7 @@ class TestAdBreak: NSObject, AdBreak {
         self.replaceContentDuration = replaceContentDuration
     }
 
-    func register(_ adItem: any Ad) {
+    func register(_ adItem: Ad) {
         ads.append(adItem)
         totalNumberOfAds = UInt(ads.count)
     }

--- a/Example/Tests/PlayerEventsTest.swift
+++ b/Example/Tests/PlayerEventsTest.swift
@@ -18,36 +18,34 @@ class PlayerEventsTest: QuickSpec {
     // swiftlint:disable:next function_body_length
     override class func spec() {
         var playerDouble: BitmovinPlayerTestDouble!
+        var convivaAnalytics: ConvivaAnalytics!
 
         beforeEach {
             playerDouble = BitmovinPlayerTestDouble()
             TestHelper.shared.spyTracker.reset()
             TestHelper.shared.mockTracker.reset()
+
+            let convivaConfig = ConvivaConfiguration()
+            convivaConfig.debugLoggingEnabled = true
+
+            do {
+                convivaAnalytics = try ConvivaAnalytics(
+                    player: playerDouble,
+                    customerKey: "",
+                    config: convivaConfig
+                )
+            } catch {
+                fail("ConvivaAnalytics failed with error: \(error)")
+            }
+        }
+
+        afterEach {
+            if convivaAnalytics != nil {
+                convivaAnalytics = nil
+            }
         }
 
         context("player event handling") {
-            var convivaAnalytics: ConvivaAnalytics!
-            beforeEach {
-                let convivaConfig = ConvivaConfiguration()
-                convivaConfig.debugLoggingEnabled = true
-
-                do {
-                    convivaAnalytics = try ConvivaAnalytics(
-                        player: playerDouble,
-                        customerKey: "",
-                        config: convivaConfig
-                    )
-                } catch {
-                    fail("ConvivaAnalytics failed with error: \(error)")
-                }
-            }
-
-            afterEach {
-                if convivaAnalytics != nil {
-                    convivaAnalytics = nil
-                }
-            }
-
             context("initialize session") {
                 var spy: Spy!
                 beforeEach {
@@ -81,15 +79,19 @@ class PlayerEventsTest: QuickSpec {
             context("initialize player state manager") {
                 it("on play") {
                     let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setPlayerInfo")
+                    let adAnalyticsSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "setPlayerInfo")
                     playerDouble.fakePlayEvent()
                     expect(spy).to(haveBeenCalled())
+                    expect(adAnalyticsSpy).to(haveBeenCalled())
                 }
             }
 
             context("not initialize player state manager") {
                 it("when initializing conviva analytics") {
                     let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setPlayerInfo")
+                    let adAnalyticsSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "setPlayerInfo")
                     expect(spy).toNot(haveBeenCalled())
+                    expect(adAnalyticsSpy).toNot(haveBeenCalled())
                 }
             }
 
@@ -337,18 +339,27 @@ class PlayerEventsTest: QuickSpec {
             }
 
             describe("ads") {
-                var spy: Spy!
-                beforeEach {
-                    spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "reportAdBreakStarted")
-                }
+                let adStartedSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdStarted")
+                let adLoadedSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdLoaded")
+                let adMetricSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdMetric")
 
                 context("track preroll ad") {
+                    let expectedAdInfo = [
+                        "c3.ad.position": "\(AdPosition.ADPOSITION_PREROLL.rawValue)",
+                        "c3.ad.technology": "Client Side"
+                    ]
+                    let expectedAdInfoArgs = ["adInfo": expectedAdInfo.toStringWithStableOrder()]
+
                     it("with string") {
                         playerDouble.fakeAdStartedEvent(position: "pre")
-                        expect(spy).to(
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
                             haveBeenCalled(
                                 withArgs: [
-                                    "adBreakInfo": "\(AdPosition.ADPOSITION_PREROLL.rawValue)"
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
                                 ]
                             )
                         )
@@ -356,94 +367,215 @@ class PlayerEventsTest: QuickSpec {
 
                     it("with percentage") {
                         playerDouble.fakeAdStartedEvent(position: "0%")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_PREROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
 
                     it("with timestamp") {
                         playerDouble.fakeAdStartedEvent(position: "00:00:00.000")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_PREROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
 
                     it("with invalid position") {
                         playerDouble.fakeAdStartedEvent(position: "start")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_PREROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
 
                     it("without position") {
                         playerDouble.fakeAdStartedEvent(position: nil)
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_PREROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
                 }
 
                 context("track midroll ad") {
+                    let expectedAdInfo = [
+                        "c3.ad.position": "\(AdPosition.ADPOSITION_MIDROLL.rawValue)",
+                        "c3.ad.technology": "Client Side"
+                    ]
+                    let expectedAdInfoArgs = ["adInfo": expectedAdInfo.toStringWithStableOrder()]
+
                     it("with percentage") {
                         playerDouble.fakeAdStartedEvent(position: "10%")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_MIDROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
 
                     it("with timestamp") {
                         _ = TestDouble(aClass: playerDouble, name: "duration", return: TimeInterval(120))
                         playerDouble.fakeAdStartedEvent(position: "00:01:00.000")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_MIDROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
                 }
 
                 context("track postroll ad") {
+                    let expectedAdInfo = [
+                        "c3.ad.position": "\(AdPosition.ADPOSITION_POSTROLL.rawValue)",
+                        "c3.ad.technology": "Client Side"
+                    ]
+                    let expectedAdInfoArgs = ["adInfo": expectedAdInfo.toStringWithStableOrder()]
+
                     it("with string") {
                         playerDouble.fakeAdStartedEvent(position: "post")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_POSTROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
 
                     it("with percentage") {
                         playerDouble.fakeAdStartedEvent(position: "100%")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_POSTROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
 
                     it("with timestamp") {
                         _ = TestDouble(aClass: playerDouble, name: "duration", return: TimeInterval(120))
                         playerDouble.fakeAdStartedEvent(position: "00:02:00.000")
-                        expect(spy).to(
-                            haveBeenCalled(withArgs: ["adBreakInfo": "\(AdPosition.ADPOSITION_POSTROLL.rawValue)"])
+
+                        expect(adStartedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adLoadedSpy).to(haveBeenCalled(withArgs: expectedAdInfoArgs))
+                        expect(adMetricSpy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "key": CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
+                                    "value": "\(PlayerState.CONVIVA_PLAYING.rawValue)"
+                                ]
+                            )
                         )
                     }
                 }
 
                 context("track ad end") {
+                    let adEndedSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdEnded")
+
                     beforeEach {
                         playerDouble.fakePlayEvent()
-                        spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "reportAdBreakEnded")
-                    }
-
-                    it("on ad skipped") {
-                        playerDouble.fakeAdSkippedEvent()
-                        expect(spy).to(haveBeenCalled())
                     }
 
                     it("on ad finished") {
                         playerDouble.fakeAdFinishedEvent()
-                        expect(spy).to(haveBeenCalled())
+                        expect(adEndedSpy).to(haveBeenCalled())
+                    }
+                }
+
+                context("track ad skipped") {
+                    let adSkippedSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdSkipped")
+
+                    beforeEach {
+                        playerDouble.fakePlayEvent()
+                    }
+
+                    it("on ad skipped") {
+                        playerDouble.fakeAdSkippedEvent()
+                        expect(adSkippedSpy).to(haveBeenCalled())
+                    }
+                }
+
+                context("track ad failed") {
+                    let adFailedSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdFailed")
+
+                    beforeEach {
+                        playerDouble.fakePlayEvent()
                     }
 
                     it("on ad error") {
                         playerDouble.fakeAdErrorEvent()
-                        expect(spy).to(haveBeenCalled())
+                        expect(adFailedSpy).to(haveBeenCalled(withArgs: ["errorMessage": "Error Message"]))
                     }
+                }
+            }
+        }
+
+        describe("releasing") {
+            describe("does a cleanup") {
+                beforeEach {
+                    convivaAnalytics.release()
+                }
+
+                it("on the video analytics") {
+                    expect(Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "cleanup")).to(haveBeenCalled())
+                }
+
+                it("on the ad analytics") {
+                    expect(Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "cleanup")).to(haveBeenCalled())
+                }
+
+                it("on the analytics") {
+                    expect(Spy(aClass: CISAnalyticsTestDouble.self, functionName: "cleanup")).to(haveBeenCalled())
                 }
             }
         }

--- a/Example/Tests/PlayerEventsTest.swift
+++ b/Example/Tests/PlayerEventsTest.swift
@@ -353,7 +353,7 @@ class PlayerEventsTest: QuickSpec {
                             haveBeenCalled(
                                 withArgs: [
                                     "adPlayer": "\(AdPlayer.ADPLAYER_CONTENT)",
-                                    "adType": "\(AdTechnology.CLIENT_SIDE)",
+                                    "adType": "\(AdTechnology.CLIENT_SIDE)"
                                 ]
                             )
                         )

--- a/Example/Tests/PlayerEventsTest.swift
+++ b/Example/Tests/PlayerEventsTest.swift
@@ -343,6 +343,34 @@ class PlayerEventsTest: QuickSpec {
                 let adLoadedSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdLoaded")
                 let adMetricSpy = Spy(aClass: CISAdAnalyticsTestDouble.self, functionName: "reportAdMetric")
 
+                context("report ad break start") {
+                    it("on ad break started event") {
+                        let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "reportAdBreakStarted")
+
+                        playerDouble.fakeAdBreakStartedEvent(position: 0.0)
+
+                        expect(spy).to(
+                            haveBeenCalled(
+                                withArgs: [
+                                    "adPlayer": "\(AdPlayer.ADPLAYER_CONTENT)",
+                                    "adType": "\(AdTechnology.CLIENT_SIDE)",
+                                    "adBreakInfo": "\(AdPosition.ADPOSITION_PREROLL.rawValue)"
+                                ]
+                            )
+                        )
+                    }
+                }
+
+                context("report ad break ended") {
+                    it("on ad break finished event") {
+                        let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "reportAdBreakEnded")
+
+                        playerDouble.fakeAdBreakFinishedEvent()
+
+                        expect(spy).to(haveBeenCalled())
+                    }
+                }
+
                 context("track preroll ad") {
                     let expectedAdInfo = [
                         "c3.ad.position": "\(AdPosition.ADPOSITION_PREROLL.rawValue)",

--- a/Example/Tests/PlayerEventsTest.swift
+++ b/Example/Tests/PlayerEventsTest.swift
@@ -354,7 +354,6 @@ class PlayerEventsTest: QuickSpec {
                                 withArgs: [
                                     "adPlayer": "\(AdPlayer.ADPLAYER_CONTENT)",
                                     "adType": "\(AdTechnology.CLIENT_SIDE)",
-                                    "adBreakInfo": "\(AdPosition.ADPOSITION_PREROLL.rawValue)"
                                 ]
                             )
                         )


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
Ad tracking is done using custom events, instead of the conviva provided ad analytics.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
- Migrate the ad tracking to the ad analytics. This PR provides a basic integration of the ad lifecycle.
- Adjust existing tests
- Add new tests for cleanup and the new ad tracking trigger 

### Notes
<!-- Anything worth pointing out -->
Finer grained tracking is implemented in follow up PRs. (To keep PR sizes smaller, or at least the production code changes)

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
