### PR TITLE
Introduce stable order stringification for dictionaries

### DIFF
--- a/Example/Tests/TestHelper.swift
+++ b/Example/Tests/TestHelper.swift
@@ -35,7 +35,7 @@ extension Dictionary where Key: Comparable {
     /// Converts the dictionary to a string with keys in stable order.
     /// - Returns: A string representation of the dictionary with sorted keys.
     func toStringWithStableOrder() -> String {
-        let sortedKeyValuePairs = self.sorted { $0.key < $1.key }
+        let sortedKeyValuePairs = sorted { $0.key < $1.key }
         let keyValuePairsString = sortedKeyValuePairs.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
         return "[\(keyValuePairsString)]"
     }

--- a/Example/Tests/TestHelper.swift
+++ b/Example/Tests/TestHelper.swift
@@ -46,9 +46,7 @@ extension Dictionary {
     /// - Returns: A new dictionary with string keys and values.
     func mapKeyAndValuesToString() -> [String: String] {
         var args = [String: String]()
-        for (key, value) in self {
-            args[String(describing: key)] = String(describing: value)
-        }
+        forEach { key, value in args[String(describing: key)] = String(describing: value) }
         return args
     }
 

--- a/Example/Tests/TestHelper.swift
+++ b/Example/Tests/TestHelper.swift
@@ -49,4 +49,10 @@ extension Dictionary {
         forEach { key, value in args[String(describing: key)] = String(describing: value) }
         return args
     }
+
+    /// Converts the dictionary to a string with keys in stable order.
+    /// - Returns: A string representation of the dictionary with sorted keys.
+    func toStringWithStableOrder() -> String {
+        mapKeyAndValuesToString().toStringWithStableOrder()
+    }
 }

--- a/Example/Tests/TestHelper.swift
+++ b/Example/Tests/TestHelper.swift
@@ -30,3 +30,31 @@ class TestHelper: NSObject {
         TestHelper.shared.mockTracker.addMock(name, returnValue: returnValue)
     }
 }
+
+extension Dictionary where Key: Comparable {
+    /// Converts the dictionary to a string with keys in stable order.
+    /// - Returns: A string representation of the dictionary with sorted keys.
+    func toStringWithStableOrder() -> String {
+        let sortedKeyValuePairs = self.sorted { $0.key < $1.key }
+        let keyValuePairsString = sortedKeyValuePairs.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+        return "[\(keyValuePairsString)]"
+    }
+}
+
+extension Dictionary {
+    /// Maps the keys and values of the dictionary to their string representations.
+    /// - Returns: A new dictionary with string keys and values.
+    func mapKeyAndValuesToString() -> [String: String] {
+        var args = [String: String]()
+        for (key, value) in self {
+            args[String(describing: key)] = String(describing: value)
+        }
+        return args
+    }
+
+    /// Converts the dictionary to a string with keys in stable order.
+    /// - Returns: A string representation of the dictionary with sorted keys.
+    func toStringWithStableOrder() -> String {
+        mapKeyAndValuesToString().toStringWithStableOrder()
+    }
+}

--- a/Example/Tests/TestHelper.swift
+++ b/Example/Tests/TestHelper.swift
@@ -49,10 +49,4 @@ extension Dictionary {
         forEach { key, value in args[String(describing: key)] = String(describing: value) }
         return args
     }
-
-    /// Converts the dictionary to a string with keys in stable order.
-    /// - Returns: A string representation of the dictionary with sorted keys.
-    func toStringWithStableOrder() -> String {
-        mapKeyAndValuesToString().toStringWithStableOrder()
-    }
 }


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
We are handling dictionaries as arguments, but want to easily verify correct arguments in our tests.
Built-in string conversions for dictionaries do not enforce a fixed order of the dictionary entries in the resulting string.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Introduce extensions to convert dictionaries to deterministic strings.

### Notes
<!-- Anything worth pointing out -->

### Checklist
- [ ] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
