### PR TITLE
Report ad playback metrics

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -560,6 +560,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
             CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
             value: PlayerState.CONVIVA_PLAYING.rawValue
         )
+        // swiftlint:disable:next identifier_name
         let ad = event.ad
         if ad.width > 0 && ad.height > 0 {
             adAnalytics.reportAdMetric(

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -382,6 +382,8 @@ public final class ConvivaAnalytics: NSObject {
     }
 
     private func handleAdUpdateRequest() {
+        guard player.isAd else { return }
+
         adAnalytics.reportPlaybackMetric(
             CIS_SSDK_PLAYBACK_METRIC_PLAY_HEAD_TIME,
             value: Int64(player.currentTime(.relativeTime) * 1_000)


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
The current integration does not report any ad playback metrics to the ad analytics.

### Changes
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
- Use `UpdateHandler` to report playhead during ads
- When transitioning playback state during an active ad, report state change to `CISAdAnalytics`
- On ad start, report RESOLUTION and BITRATE depending on availability

### Notes
<!-- Anything worth pointing out -->

### Checklist
- [ ] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
