### PR TITLE
Fix `imaVersionString` property name

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -12,7 +12,16 @@ import Foundation
 public struct MetadataOverrides {
     // Can only be set once
     public var assetName: String?
-    public var imaSdkVerison: String?
+    @available(*, deprecated, message: "Use imaSdkVersion instead", renamed: "imaSdkVersion")
+    public var imaSdkVerison: String? {
+        get {
+            imaSdkVersion
+        }
+        set {
+            imaSdkVersion = newValue
+        }
+    }
+    public var imaSdkVersion: String?
 
     // Can only be set before playback started
     public var viewerId: String?

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -417,7 +417,7 @@ public final class ConvivaAnalytics: NSObject {
             adInfo[CIS_SSDK_PLAYER_FRAMEWORK_NAME] = "Google IMA SDK"
             adInfo[CIS_SSDK_PLAYER_FRAMEWORK_VERSION] = contentMetadataBuilder
                 .metadataOverrides
-                .imaSdkVerison ?? notAvailable
+                .imaSdkVersion ?? notAvailable
         } else {
             adInfo[CIS_SSDK_PLAYER_FRAMEWORK_NAME] = "Bitmovin"
             adInfo[CIS_SSDK_PLAYER_FRAMEWORK_VERSION] = playerHelper.version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `MetadataOverrides.imaSdkVersion` as a replacement for `MetadataOverrides.imaSdkVerison` to set the IMA SDK version
+
+### Deprecated
+- `MetadataOverrides.imaSdkVerison` in favor of `MetadataOverrides.imaSdkVersion`
+
 ## [3.2.0] - 2024-06-07
 
 ### Added

--- a/Example/BitmovinConvivaAnalytics/ViewController.swift
+++ b/Example/BitmovinConvivaAnalytics/ViewController.swift
@@ -68,8 +68,7 @@ class ViewController: UIViewController {
         metadata.custom = ["custom_tag": "Episode"]
         metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
 
-        metadata.imaSdkVerison = Bundle(for: IMAAdsManager.self)
-            .infoDictionary?["CFBundleShortVersionString"] as? String
+        metadata.imaSdkVersion = IMAAdsLoader.sdkVersion()
 
         do {
             convivaAnalytics = try ConvivaAnalytics(

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
 metadata.custom = ["custom_tag": "value"]
 metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
 
-metadata.imaSdkVerison = Bundle(for: IMAAdsManager.self).infoDictionary?["CFBundleShortVersionString"] as? String
+metadata.imaSdkVerison = IMAAdsLoader.sdkVersion()
 
 // …
 // Initialize ConvivaAnalytics


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
There is a typo in `MetadataOverrides.imaSdkVerison`, this PR fixes it.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Added a new property called `imaSdkVersion` and deprecated `imaSdkVerison` with getting and setting its value to the new property.

### Notes
<!-- Anything worth pointing out -->
Also improved the IMA version detection in the Example application.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
