### PR TITLE
Fix missing ad info reporting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -45,7 +45,6 @@ opt_in_rules:
   - override_in_extension
   - quick_discouraged_call
   - quick_discouraged_focused_test
-  - unused_import
   - yoda_condition
 
   #style

--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -20,8 +20,8 @@ Conviva Analytics Integration for the Bitmovin Player iOS SDK
   s.swift_version = '5.0'
   s.cocoapods_version = '>= 1.9.0'
 
-  s.ios.dependency 'BitmovinPlayer', '~> 3.63'
-  s.tvos.dependency 'BitmovinPlayer', '~> 3.63'
+  s.ios.dependency 'BitmovinPlayer', '~> 3.64'
+  s.tvos.dependency 'BitmovinPlayer', '~> 3.64'
   s.ios.dependency 'ConvivaSDK', '~> 4.0'
   s.tvos.dependency 'ConvivaSDK', '~> 4.0'
 

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -455,8 +455,14 @@ public final class ConvivaAnalytics: NSObject {
         if let adSystem = vastAdData.adSystem {
             adInfo["c3.ad.system"] = adSystem
         }
-        if !vastAdData.wrapperAdIds.isEmpty {
-            adInfo["c3.ad.firstAdId"] = vastAdData.wrapperAdIds.last
+        if let firstAdId = vastAdData.wrapperAdIds.last {
+            adInfo["c3.ad.firstAdId"] = firstAdId
+        }
+        if let firstCreativeId = vastAdData.wrapperCreativeIds.last {
+            adInfo["c3.ad.firstCreativeId"] = firstCreativeId
+        }
+        if let firstAdSystem = vastAdData.wrapperAdSystems.last {
+            adInfo["c3.ad.firstAdSystem"] = firstAdSystem
         }
     }
 }

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -444,7 +444,7 @@ public final class ConvivaAnalytics: NSObject {
     }
 
     private func setVastAdMetadata(adInfo: inout [String: Any], vastAdData: VastAdData) {
-        adInfo["c3.ad.description"] = vastAdData.description
+        adInfo["c3.ad.description"] = vastAdData.adDescription
 
         if let adTitle = vastAdData.adTitle {
             adInfo[CIS_SSDK_METADATA_ASSET_NAME] = adTitle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Deprecated
 - `MetadataOverrides.imaSdkVerison` in favor of `MetadataOverrides.imaSdkVersion`
 
+### Fixed
+- Wrong value tracked for `c3.ad.description` for VAST client side ads
+
 ### Internal
 - `ConvivaAnalytics` internal state is now stored in private properties
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `MetadataOverrides.imaSdkVersion` as a replacement for `MetadataOverrides.imaSdkVerison` to set the IMA SDK version
+- Tracking of `c3.ad.firstCreativeId` and `c3.ad.firstAdSystem` tags for VAST client side ads
 
 ### Changed
 - Updated minimum Bitmovin Player version to 3.64.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `MetadataOverrides.imaSdkVersion` as a replacement for `MetadataOverrides.imaSdkVerison` to set the IMA SDK version
 
+### Changed
+- Updated minimum Bitmovin Player version to 3.64.0
+
 ### Deprecated
 - `MetadataOverrides.imaSdkVerison` in favor of `MetadataOverrides.imaSdkVersion`
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ source 'https://cdn.cocoapods.org/'
 
 def shared_pods
   pod 'BitmovinConvivaAnalytics', path: '../'
-  pod 'BitmovinPlayer', '3.63.0'
+  pod 'BitmovinPlayer', '3.64.0'
   pod 'ConvivaSDK', '4.0.49'
 end
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - BitmovinAnalyticsCollector/BitmovinPlayer (3.6.2):
+  - BitmovinAnalyticsCollector/BitmovinPlayer (3.7.0):
     - BitmovinAnalyticsCollector/Core
     - BitmovinPlayerCore (~> 3.48)
-  - BitmovinAnalyticsCollector/Core (3.6.2)
+  - BitmovinAnalyticsCollector/Core (3.7.0)
   - BitmovinConvivaAnalytics (3.2.0):
     - BitmovinPlayer (~> 3.63)
     - ConvivaSDK (~> 4.0)
-  - BitmovinPlayer (3.63.0):
+  - BitmovinPlayer (3.64.0):
     - BitmovinAnalyticsCollector/BitmovinPlayer (~> 3.0)
-    - BitmovinPlayerCore (= 3.63.0)
-  - BitmovinPlayerCore (3.63.0)
+    - BitmovinPlayerCore (= 3.64.0)
+  - BitmovinPlayerCore (3.64.0)
   - ConvivaSDK (4.0.49)
   - CwlCatchException (2.2.0):
     - CwlCatchExceptionSupport (~> 2.2.0)
@@ -28,7 +28,7 @@ PODS:
 
 DEPENDENCIES:
   - BitmovinConvivaAnalytics (from `../`)
-  - BitmovinPlayer (= 3.63.0)
+  - BitmovinPlayer (= 3.64.0)
   - ConvivaSDK (= 4.0.49)
   - GoogleAds-IMA-iOS-SDK (= 3.22.1)
   - GoogleAds-IMA-tvOS-SDK (= 4.12.0)
@@ -57,10 +57,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BitmovinAnalyticsCollector: 78308c1c02ee0390554c377204fcbab923369296
+  BitmovinAnalyticsCollector: bbd82c0b8e11aefacd8e53b6e40c62f2cba6f3f5
   BitmovinConvivaAnalytics: f7078baeee0fd5d95afd936dfb4e2d8b35b6a27d
-  BitmovinPlayer: f697e7c11554ee45e7f42f824359a4e9ebc81e0e
-  BitmovinPlayerCore: f50c383ea03927fadbdf85b585916461975192e3
+  BitmovinPlayer: f69350e5db2f57ad950108ec829b7c7a4b360d00
+  BitmovinPlayerCore: 1553570729eed0a64cdfbd06d16c39d69d7e701f
   ConvivaSDK: 5d10811e8611ed1fd99a5ab291bdcb1e795f8756
   CwlCatchException: 51bf8319009a31104ea6f0568730d1ecc25b6454
   CwlCatchExceptionSupport: 1345d6adb01a505933f2bc972dab60dcb9ce3e50
@@ -72,6 +72,6 @@ SPEC CHECKSUMS:
   Nimble: 3ac6c6b0b7e9835d1540b6507d8054b12a415536
   Quick: 2b651168441479b949ba987f3cee41a9cc53aa32
 
-PODFILE CHECKSUM: 361ba3271d83e72ba53583701a9f6253857117ab
+PODFILE CHECKSUM: 7c46997cf928147ddff32915a3194ff8947b03e2
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
In #72 we missed tracking two ads related tags because the needed information was only present on a player SDK update.

+1 ad description was tracked with the wrong value.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Added tracking of `c3.ad.firstCreativeId` and `c3.ad.firstAdSystem`.

+1 fixed `c3.ad.description` tag value.

### Notes
<!-- Anything worth pointing out -->
I updated the min. player SDK requirement to `3.64.0`.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
