### PR TITLE
Fix missing content length with autoplay enabled

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -300,12 +300,13 @@ private extension ConvivaAnalytics {
         }
 
         setupPlayerStateManager()
-        updateSession()
 
         videoAnalytics.reportPlaybackRequested(contentMetadataBuilder.build())
         logger.debugLog(message: "Creating session with metadata: \(contentMetadataBuilder)")
         logger.debugLog(message: "Session started")
         isSessionActive = true
+
+        updateSession()
     }
 
     private func updateSession() {

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -539,6 +539,10 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         internalEndSession()
     }
 
+    func onSourceLoaded() {
+        updateSession()
+    }
+
     func onTimeChanged() {
         reportPlayHeadTime()
         updateSession()

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
@@ -38,6 +38,10 @@ extension BitmovinPlayerListener: PlayerListener {
         }
     }
 
+    func onSourceLoaded(_ event: SourceLoadedEvent, player: any Player) {
+        delegate?.onSourceLoaded()
+    }
+
     func onTimeChanged(_ event: TimeChangedEvent, player: Player) {
         delegate?.onTimeChanged()
     }

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
@@ -12,6 +12,7 @@ import Foundation
 protocol BitmovinPlayerListenerDelegate: AnyObject {
     func onEvent(_ event: Event)
     func onSourceUnloaded()
+    func onSourceLoaded()
     func onTimeChanged()
     func onPlayerError(_ event: PlayerErrorEvent)
     func onSourceError(_ event: SourceErrorEvent)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Missing content length reporting when autoplay is enabled
+
 ## [3.3.0] - 2024-07-04
 
 ### Added

--- a/Example/Tests/ContentMetadataTest.swift
+++ b/Example/Tests/ContentMetadataTest.swift
@@ -114,10 +114,9 @@ class ContentMetadataTest: QuickSpec {
 
             context("when updating session") {
                 it("update video duration") {
+                    _ = TestDouble(aClass: playerDouble!, name: "duration", return: 50.0)
+
                     playerDouble.fakePlayEvent() // to initialize session
-                    var metadata = MetadataOverrides()
-                    metadata.duration = 50
-                    convivaAnalytics.updateContentMetadata(metadataOverrides: metadata)
                     let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setContentInfo")
 
                     expect(spy).to(
@@ -142,10 +141,9 @@ class ContentMetadataTest: QuickSpec {
                 }
 
                 it("update stream type (VOD/Live)") {
+                    _ = TestDouble(aClass: playerDouble!, name: "isLive", return: true)
+
                     playerDouble.fakePlayEvent() // to initialize session
-                    var metadata = MetadataOverrides()
-                    metadata.streamType = StreamType.CONVIVA_STREAM_LIVE
-                    convivaAnalytics.updateContentMetadata(metadataOverrides: metadata)
                     let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setContentInfo")
 
                     expect(spy).to(

--- a/Example/Tests/ContentMetadataTest.swift
+++ b/Example/Tests/ContentMetadataTest.swift
@@ -125,6 +125,22 @@ class ContentMetadataTest: QuickSpec {
                     )
                 }
 
+                describe("when duration is not yet available on play") {
+                    it("update video duration on source loaded") {
+                        _ = TestDouble(aClass: playerDouble!, name: "duration", return: 0.0)
+                        playerDouble.fakePlayEvent() // to initialize session
+
+                        _ = TestDouble(aClass: playerDouble!, name: "duration", return: 50.0)
+                        playerDouble.fakeSourceLoadedEvent() // to initialize session
+
+                        let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setContentInfo")
+
+                        expect(spy).to(
+                            haveBeenCalled(withArgs: ["duration": "50"])
+                        )
+                    }
+                }
+
                 it("update stream type (VOD/Live)") {
                     playerDouble.fakePlayEvent() // to initialize session
                     var metadata = MetadataOverrides()

--- a/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
+++ b/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
@@ -134,6 +134,13 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
         onTimeChanged(TimeChangedEvent(currentTime: 1), player)
     }
 
+    func fakeSourceLoadedEvent() {
+        guard let onSourceLoaded = fakeListener?.onSourceLoaded else {
+            return
+        }
+        onSourceLoaded(SourceLoadedEvent(source: fakeSource), player)
+    }
+
     func fakeSourceUnloadedEvent() {
         guard let onSourceUnloaded = fakeListener?.onSourceUnloaded else {
             return


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
When autoplay is enabled via `PlaybackConfig.isAutoplayEnabled`, the `contentLength` is not reported early enough. This is because the Play intention, aka the `PlayEvent`, is emitted before the `duration` is available. This yields an error in touchstone when looking at those sessions. _The player's behaviour is considered as expected._

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
The earliest point where we can reliable access the duration is inside the `SourceLoadedEvent`. Therefore we now also update the dynamic content metadata (which the duration is) also from the `SourceLoadedEvent`.

### Notes
<!-- Anything worth pointing out -->
This issue could also occur without autoplay when play is called before the source finishes loading, e.g. in a bad network. So this change makes sense regardless of autoplay or not.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
