### PR TITLE
Fix invalid session ID in post roll ad sessions

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -36,6 +36,7 @@ public final class ConvivaAnalytics: NSObject {
     private var isStalled = false
     private var playbackStarted = false
     private var isSsaiAdBreakActive = false
+    private var playbackFinishedDispatchWorkItem: DispatchWorkItem?
 
     // MARK: - Public Attributes
     /**
@@ -526,6 +527,16 @@ private extension ConvivaAnalytics {
             adInfo["c3.ad.firstAdSystem"] = firstAdSystem
         }
     }
+
+    private func maybeCancelEndSessionBeforePostRoll() {
+        playbackFinishedDispatchWorkItem?.cancel()
+    }
+
+    private func maybeEndSessionAfterPostRoll() {
+        guard playbackFinishedDispatchWorkItem != nil else { return }
+        playbackFinishedDispatchWorkItem = nil
+        internalEndSession()
+    }
 }
 
 // MARK: - PlayerListener
@@ -592,7 +603,14 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
 
     func onPlaybackFinished() {
         onPlaybackStateChanged(playerState: .CONVIVA_STOPPED)
-        internalEndSession()
+        let playbackFinishedDispatchWorkItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  let currentWorkItem = self.playbackFinishedDispatchWorkItem,
+                  !currentWorkItem.isCancelled else { return }
+            self.internalEndSession()
+        }
+        self.playbackFinishedDispatchWorkItem = playbackFinishedDispatchWorkItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10, execute: playbackFinishedDispatchWorkItem)
     }
 
     func onStallStarted() {
@@ -694,6 +712,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     }
 
     func onAdBreakStarted(_ event: AdBreakStartedEvent) {
+        maybeCancelEndSessionBeforePostRoll()
         videoAnalytics.reportAdBreakStarted(
             AdPlayer.ADPLAYER_CONTENT,
             adType: AdTechnology.CLIENT_SIDE,
@@ -705,6 +724,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     func onAdBreakFinished(_ event: AdBreakFinishedEvent) {
         videoAnalytics.reportAdBreakEnded()
         customEvent(event: event)
+        maybeEndSessionAfterPostRoll()
     }
 
     func onDestroy() {
@@ -737,6 +757,8 @@ extension ConvivaAnalytics: SsaiApiDelegate {
         guard !isSsaiAdBreakActive else { return }
         isSsaiAdBreakActive = true
 
+        maybeCancelEndSessionBeforePostRoll()
+
         videoAnalytics.reportAdBreakStarted(
             .ADPLAYER_CONTENT,
             adType: .SERVER_SIDE,
@@ -749,6 +771,8 @@ extension ConvivaAnalytics: SsaiApiDelegate {
 
         isSsaiAdBreakActive = false
         videoAnalytics.reportAdBreakEnded()
+
+        maybeEndSessionAfterPostRoll()
     }
 
     func ssaiApi_reportAdStarted(adInfo: SsaiAdInfo) {

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -613,12 +613,12 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
             self.internalEndSession()
         }
         self.playbackFinishedDispatchWorkItem = playbackFinishedDispatchWorkItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10, execute: playbackFinishedDispatchWorkItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100), execute: playbackFinishedDispatchWorkItem)
     }
 
     func onStallStarted() {
         isStalled = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
             guard let self else { return }
             self.logger.debugLog(
                 message: "[ ConvivaAnalytics ] calling StallStarted after 0.10 seconds"

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -597,7 +597,8 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
 
     func onStallStarted() {
         isStalled = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) { [weak self] in
+            guard let self else { return }
             self.logger.debugLog(
                 message: "[ ConvivaAnalytics ] calling StallStarted after 0.10 seconds"
             )

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -358,6 +358,9 @@ private extension ConvivaAnalytics {
             return
         }
 
+        playbackFinishedDispatchWorkItem?.cancel()
+        playbackFinishedDispatchWorkItem = nil
+
         if isSsaiAdBreakActive {
             adAnalytics.reportAdEnded()
             videoAnalytics.reportAdBreakEnded()

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
@@ -33,8 +33,8 @@ extension BitmovinPlayerListener: PlayerListener {
         // The default SDK error handling is that it triggers the onSourceUnloaded before the onError event.
         // To track errors to conviva we need to delay the onSourceUnloaded to ensure the onError event is
         // called first.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.delegate?.onSourceUnloaded()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.delegate?.onSourceUnloaded()
         }
     }
 

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
@@ -33,7 +33,7 @@ extension BitmovinPlayerListener: PlayerListener {
         // The default SDK error handling is that it triggers the onSourceUnloaded before the onError event.
         // To track errors to conviva we need to delay the onSourceUnloaded to ensure the onError event is
         // called first.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
             self?.delegate?.onSourceUnloaded()
         }
     }

--- a/Example/Tests/PlayerEventsTest.swift
+++ b/Example/Tests/PlayerEventsTest.swift
@@ -145,15 +145,19 @@ class PlayerEventsTest: QuickSpec {
                     playerDouble.fakePlayingEvent()
                     playerDouble.fakeStallStartedEvent()
                     playerDouble.fakeStallEndedEvent()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
-                        expect(spy).notTo(
-                            haveBeenCalled(
-                                withArgs: [
-                                    CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE: "\(PlayerState.CONVIVA_BUFFERING.rawValue)"
-                                ]
-                            )
-                        )
+                    waitUntil { done in
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                            done()
+                        }
                     }
+                    expect(spy).notTo(
+                        haveBeenCalled(
+                            withArgs: [
+                                CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE:
+                                    "\(PlayerState.CONVIVA_BUFFERING.rawValue)"
+                            ]
+                        )
+                    )
                 }
                 it("on stall started/Stall Ended no wait") {
                     playerDouble.fakePlayingEvent()
@@ -170,28 +174,34 @@ class PlayerEventsTest: QuickSpec {
                 it("on stall started / Stall Ended after 0.10 seconds") {
                     playerDouble.fakePlayingEvent()
                     playerDouble.fakeStallStartedEvent()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
-                        playerDouble.fakeStallEndedEvent()
-                        expect(spy).to(
-                            haveBeenCalled(
-                                withArgs: [
-                                    CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE: "\(PlayerState.CONVIVA_BUFFERING.rawValue)"
-                                ]
-                            )
-                        )
+                    waitUntil { done in
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                            playerDouble.fakeStallEndedEvent()
+                            done()
+                        }
                     }
+                    expect(spy).to(
+                        haveBeenCalled(
+                            withArgs: [
+                                CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE: "\(PlayerState.CONVIVA_BUFFERING.rawValue)"
+                            ]
+                        )
+                    )
                 }
                 it("on stall started") {
                     playerDouble.fakeStallStartedEvent()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
-                        expect(spy).to(
-                            haveBeenCalled(
-                                withArgs: [
-                                    CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE: "\(PlayerState.CONVIVA_BUFFERING.rawValue)"
-                                ]
-                            )
-                        )
+                    waitUntil { done in
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                            done()
+                        }
                     }
+                    expect(spy).to(
+                        haveBeenCalled(
+                            withArgs: [
+                                CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE: "\(PlayerState.CONVIVA_BUFFERING.rawValue)"
+                            ]
+                        )
+                    )
                 }
 
                 context("after stalling") {

--- a/Example/Tests/PlayerEventsTest.swift
+++ b/Example/Tests/PlayerEventsTest.swift
@@ -102,7 +102,7 @@ class PlayerEventsTest: QuickSpec {
                         playerDouble.fakePlayEvent()
                         playerDouble.fakePlaybackFinishedEvent()
                         waitUntil { done in
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                                 done()
                             }
                         }
@@ -116,7 +116,7 @@ class PlayerEventsTest: QuickSpec {
                         playerDouble.fakePlaybackFinishedEvent()
                         playerDouble.fakeAdBreakStartedEvent()
                         waitUntil { done in
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                                 done()
                             }
                         }
@@ -175,7 +175,7 @@ class PlayerEventsTest: QuickSpec {
                     playerDouble.fakeStallStartedEvent()
                     playerDouble.fakeStallEndedEvent()
                     waitUntil { done in
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                             done()
                         }
                     }
@@ -204,7 +204,7 @@ class PlayerEventsTest: QuickSpec {
                     playerDouble.fakePlayingEvent()
                     playerDouble.fakeStallStartedEvent()
                     waitUntil { done in
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                             playerDouble.fakeStallEndedEvent()
                             done()
                         }
@@ -220,7 +220,7 @@ class PlayerEventsTest: QuickSpec {
                 it("on stall started") {
                     playerDouble.fakeStallStartedEvent()
                     waitUntil { done in
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                             done()
                         }
                     }
@@ -297,7 +297,7 @@ class PlayerEventsTest: QuickSpec {
                         playerDouble.fakePlayEvent()
                         playerDouble.fakePlaybackFinishedEvent()
                         waitUntil { done in
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                                 done()
                             }
                         }
@@ -319,7 +319,7 @@ class PlayerEventsTest: QuickSpec {
                     playerDouble.fakePlayEvent()
                     playerDouble.fakePlaylistTransitionEvent()
                     waitUntil { done in
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
                             done()
                         }
                     }


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
When playing a post-roll ad, "invalid session ID" error shows up on Conviva Touchstone.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Postponing ending the session from `onPlaybackFinished` event with a delay of `0.1s` to check if there is an `onAdBreakStarted` event is received and then only end the session once `onAdBreakFinished` event is seen fixes the problem.

### Notes
<!-- Anything worth pointing out -->
Both CSAI and SSAI ad integration were adjusted to address the problem overall.

### Checklist
- [x] I added an update to `CHANGELOG.md` file - already added in #81
- [x] I ran all the tests in the project and they succeed
