### PR TITLE
Fix reporting content length for live streams

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -93,10 +93,8 @@ class ContentMetadataBuilder: CustomStringConvertible {
                 contentInfo[CIS_SSDK_METADATA_IS_LIVE] = type
                 == StreamType.CONVIVA_STREAM_LIVE ? NSNumber(value: true) : NSNumber(value: false)
             }
-            if let duration = self.duration, duration > 0 {
+            if let duration, duration != 0 {
                 contentInfo[CIS_SSDK_METADATA_DURATION] = duration
-            } else {
-                contentInfo[CIS_SSDK_METADATA_DURATION] = -1
             }
             if let custom = self.custom {
                 contentInfo.merge(custom) { $1 }
@@ -106,12 +104,10 @@ class ContentMetadataBuilder: CustomStringConvertible {
             }
         } else {
             let oldDuration = contentInfo[CIS_SSDK_METADATA_DURATION] as? Int
-            if oldDuration == nil || oldDuration == 0 {
-                if let duration = self.duration, duration > 0 {
-                    contentInfo[CIS_SSDK_METADATA_DURATION] = duration
-                } else {
-                    contentInfo[CIS_SSDK_METADATA_DURATION] = -1
-                }
+            if oldDuration == 0,
+               let duration,
+               duration != 0 {
+                contentInfo[CIS_SSDK_METADATA_DURATION] = duration
             }
         }
 

--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -105,8 +105,8 @@ class ContentMetadataBuilder: CustomStringConvertible {
                 contentInfo.merge(additionalStandardTags) { $1 }
             }
         } else {
-            if let oldDuration = contentInfo[CIS_SSDK_METADATA_DURATION] as? Int,
-               oldDuration == 0 {
+            let oldDuration = contentInfo[CIS_SSDK_METADATA_DURATION] as? Int
+            if oldDuration == nil || oldDuration == 0 {
                 if let duration = self.duration, duration > 0 {
                     contentInfo[CIS_SSDK_METADATA_DURATION] = duration
                 } else {

--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -95,6 +95,8 @@ class ContentMetadataBuilder: CustomStringConvertible {
             }
             if let duration = self.duration, duration > 0 {
                 contentInfo[CIS_SSDK_METADATA_DURATION] = duration
+            } else {
+                contentInfo[CIS_SSDK_METADATA_DURATION] = -1
             }
             if let custom = self.custom {
                 contentInfo.merge(custom) { $1 }
@@ -103,11 +105,12 @@ class ContentMetadataBuilder: CustomStringConvertible {
                 contentInfo.merge(additionalStandardTags) { $1 }
             }
         } else {
-            if let duration = self.duration, duration > 0 {
-                if let newDuration = contentInfo[CIS_SSDK_METADATA_DURATION] as? Int {
-                    if newDuration == 0 {
-                        contentInfo[CIS_SSDK_METADATA_DURATION] = duration
-                    }
+            if let oldDuration = contentInfo[CIS_SSDK_METADATA_DURATION] as? Int,
+               oldDuration == 0 {
+                if let duration = self.duration, duration > 0 {
+                    contentInfo[CIS_SSDK_METADATA_DURATION] = duration
+                } else {
+                    contentInfo[CIS_SSDK_METADATA_DURATION] = -1
                 }
             }
         }

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -406,11 +406,7 @@ private extension ConvivaAnalytics {
     }
 
     private func buildDynamicContentMetadata() {
-        if !player.isLive, player.duration.isFinite {
-            contentMetadataBuilder.duration = Int(player.duration)
-        } else {
-            contentMetadataBuilder.duration = nil
-        }
+        contentMetadataBuilder.duration = player.isLive ? -1 : Int(player.duration)
         contentMetadataBuilder.streamType = player.isLive ? .CONVIVA_STREAM_LIVE : .CONVIVA_STREAM_VOD
         contentMetadataBuilder.streamUrl = player.source?.sourceConfig.url.absoluteString
     }

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -408,6 +408,8 @@ private extension ConvivaAnalytics {
     private func buildDynamicContentMetadata() {
         if !player.isLive, player.duration.isFinite {
             contentMetadataBuilder.duration = Int(player.duration)
+        } else {
+            contentMetadataBuilder.duration = nil
         }
         contentMetadataBuilder.streamType = player.isLive ? .CONVIVA_STREAM_LIVE : .CONVIVA_STREAM_VOD
         contentMetadataBuilder.streamUrl = player.source?.sourceConfig.url.absoluteString

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Missing viewer ID and Player Name collection for client-side ads
 - Invalid session ID errors in Conviva Touchstone when using ads
+- Missing metadata Content Length error reported for live streams
 
 ## [3.3.1] - 2024-07-14
 

--- a/Example/Tests/ContentMetadataTest.swift
+++ b/Example/Tests/ContentMetadataTest.swift
@@ -113,15 +113,31 @@ class ContentMetadataTest: QuickSpec {
             }
 
             context("when updating session") {
-                it("update video duration") {
-                    _ = TestDouble(aClass: playerDouble!, name: "duration", return: 50.0)
+                context("with VOD stream") {
+                    it("update video duration") {
+                        _ = TestDouble(aClass: playerDouble!, name: "isLive", return: false)
+                        _ = TestDouble(aClass: playerDouble!, name: "duration", return: 50.0)
 
-                    playerDouble.fakePlayEvent() // to initialize session
-                    let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setContentInfo")
+                        playerDouble.fakePlayEvent() // to initialize session
+                        let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setContentInfo")
 
-                    expect(spy).to(
-                        haveBeenCalled(withArgs: ["duration": "50"])
-                    )
+                        expect(spy).to(
+                            haveBeenCalled(withArgs: ["duration": "50"])
+                        )
+                    }
+                }
+                context("with live stream") {
+                    it("update video duration") {
+                        _ = TestDouble(aClass: playerDouble!, name: "isLive", return: true)
+                        _ = TestDouble(aClass: playerDouble!, name: "duration", return: Double.infinity)
+
+                        playerDouble.fakePlayEvent() // to initialize session
+                        let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setContentInfo")
+
+                        expect(spy).to(
+                            haveBeenCalled(withArgs: ["duration": "-1"])
+                        )
+                    }
                 }
 
                 describe("when duration is not yet available on play") {


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
Conviva Touchstone tool shows "Missing metadata Content Length" error when playing a live stream.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Assign `-1` in case a live stream is detected.
Additionally ensure to always report the up-to-date duration.

### Notes
<!-- Anything worth pointing out -->
The special value `-1` came from trial and error. I couldn't find any related information in the Conviva SDK documentation to fix the error. I have tried many options but no other resulted in the error disappearing.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
