### PR TITLE
Add warning logs

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -68,7 +68,7 @@ class ContentMetadataBuilder: CustomStringConvertible {
     func setOverrides(_ metadataOverrides: MetadataOverrides) {
         if playbackStarted {
             logger.debugLog(
-                message: "[ Conviva Analytics ] Playback has started. Only some metadata attributes will be updated"
+                message: "Playback has started. Only some metadata attributes will be updated"
             )
         }
 

--- a/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
+++ b/BitmovinConvivaAnalytics/Classes/ContentMetadataBuilder.swift
@@ -77,6 +77,28 @@ class ContentMetadataBuilder: CustomStringConvertible {
 
     func setPlaybackStarted(_ playbackStarted: Bool) {
         self.playbackStarted = playbackStarted
+
+        guard playbackStarted else { return }
+
+        let buildMissingMetadataWarningMessage: (_ metadataName: String) -> String = { name in
+            """
+            [ Warning ] `\(name)` not set but playback started. \
+            Please provide `\(name)` through \
+            `ConvivaAnalytics.updateContentMetadata(metadataOverrides:)` before playback starts
+            """
+        }
+
+        if viewerId == nil {
+            logger.debugLog(
+                message: buildMissingMetadataWarningMessage("viewerId")
+            )
+        }
+
+        if applicationName == nil {
+            logger.debugLog(
+                message: buildMissingMetadataWarningMessage("applicationName")
+            )
+        }
     }
 
     func build() -> [String: Any] {

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -155,7 +155,7 @@ public final class ConvivaAnalytics: NSObject {
 
         if !isSessionActive {
             logger.debugLog(
-                message: "[ ConvivaAnalytics ] no active session; Don\'t propagate content metadata to conviva."
+                message: "No active session; Don\'t propagate content metadata to conviva."
             )
             return
         }
@@ -435,7 +435,7 @@ private extension ConvivaAnalytics {
         // do not report any stalling when isStalled false (StallEnded triggered immediatelly after StallStarted)
         else if !isStalled, playerState == .CONVIVA_BUFFERING {
             self.logger.debugLog(
-                message: "[ ConvivaAnalytics ] false stalling, not registering to Conviva"
+                message: "False stalling, not registering to Conviva"
             )
             return
         }
@@ -619,7 +619,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
             guard let self else { return }
             self.logger.debugLog(
-                message: "[ ConvivaAnalytics ] calling StallStarted after 0.10 seconds"
+                message: "Calling StallStarted after 0.10 seconds"
             )
             self.onPlaybackStateChanged(playerState: .CONVIVA_BUFFERING)
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Warning logs in case the `viewerId` or `applicationName` is missing
+
 ## [3.3.2] - 2024-07-26
 
 ### Fixed


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
When the `applicationName` or the `viewerId` is not set before playback started, touchstone will show an error but it's not obvious how to fix it.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Added warning logs in case those properties are missing.

+1 Cleanup existing logs to not show duplicated `[ ConvivaAnalytics ]` prefix

### Notes
<!-- Anything worth pointing out -->

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
