### PR TITLE
Support late player attaching

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -38,8 +38,6 @@ public final class ConvivaAnalytics: NSObject {
     private var isSsaiAdBreakActive = false
     private var playbackFinishedDispatchWorkItem: DispatchWorkItem?
 
-    private var reportPlaybackRequestedTimeStamp: TimeInterval?
-
     // MARK: - Public Attributes
     /**
      Set the PlayerView to enable view triggered events like fullscreen state changes
@@ -327,8 +325,6 @@ private extension ConvivaAnalytics {
 
         setupPlayerStateManager()
 
-        print("[log] reportPlaybackRequested \(Date().timeIntervalSince1970)")
-        reportPlaybackRequestedTimeStamp = Date().timeIntervalSince1970
         videoAnalytics.reportPlaybackRequested(contentMetadataBuilder.build())
         logger.debugLog(message: "Creating session with metadata: \(contentMetadataBuilder)")
         logger.debugLog(message: "Session started")
@@ -630,11 +626,7 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         playbackStarted = true
         contentMetadataBuilder.setPlaybackStarted(true)
         updateSession()
-        print("[log] reporting playing \(Date().timeIntervalSince1970)")
         onPlaybackStateChanged(playerState: .CONVIVA_PLAYING)
-
-        guard let reportPlaybackRequestedTimeStamp else { return }
-        print("[log] local vst inside conviva: \(Date().timeIntervalSince1970 - reportPlaybackRequestedTimeStamp)")
     }
 
     func onPaused() {
@@ -721,8 +713,6 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
         let adInfo = buildAdInfo(adStartedEvent: event)
         adAnalytics.reportAdLoaded(adInfo)
         adAnalytics.reportAdStarted(adInfo)
-        guard let reportPlaybackRequestedTimeStamp else { return }
-        print("[log] local ad vst inside conviva: \(Date().timeIntervalSince1970 - reportPlaybackRequestedTimeStamp)")
         adAnalytics.reportAdMetric(
             CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE,
             value: PlayerState.CONVIVA_PLAYING.rawValue
@@ -754,9 +744,6 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     }
 
     func onAdBreakStarted(_ event: AdBreakStartedEvent) {
-        guard let reportPlaybackRequestedTimeStamp else { return }
-        print("[log] local ad break vst inside conviva: \(Date().timeIntervalSince1970 - reportPlaybackRequestedTimeStamp)")
-
         maybeCancelEndSessionBeforePostRoll()
         videoAnalytics.reportAdBreakStarted(
             AdPlayer.ADPLAYER_CONTENT,

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -304,6 +304,15 @@ public final class ConvivaAnalytics: NSObject {
             return
         }
 
+        if player.source != nil {
+            logger.debugLog(
+                message: """
+                         [ Warning ] There is already a Source loaded into the Player instance! \
+                         This method should be called before loading a Source.
+                         """
+            )
+        }
+
         self.player = player
         updateSession()
 

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -292,7 +292,7 @@ public final class ConvivaAnalytics: NSObject {
     }
 
     /// Attaches a `Player` instance to the Conviva Analytics object.
-    /// We suggest to call this method as soon as the `Player` instance is initialized to not mis any tracking.
+    /// This method should be called as soon as the `Player` instance is initialized to not miss any tracking.
     ///
     /// Has no effect if there is already an `Player` instance set. Use the `ConvivaAnalytics.init` without `player`
     /// if you plan to attach an `Player` instance later in the life-cycle.

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -294,8 +294,8 @@ public final class ConvivaAnalytics: NSObject {
     /// Attaches a `Player` instance to the Conviva Analytics object.
     /// This method should be called as soon as the `Player` instance is initialized to not miss any tracking.
     ///
-    /// Has no effect if there is already an `Player` instance set. Use the `ConvivaAnalytics.init` without `player`
-    /// if you plan to attach an `Player` instance later in the life-cycle.
+    /// Has no effect if there is already a `Player` instance set. Use the `ConvivaAnalytics.init` without `player`
+    /// if you plan to attach a `Player` instance later in the life-cycle.
     public func attach(player: Player) {
         if self.player != nil {
             logger.debugLog(

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -66,14 +66,12 @@ public final class ConvivaAnalytics: NSObject {
     }
 
     // MARK: - initializer
-    /**
-     Initialize a new Bitmovin Conviva Analytics object to track metrics from Bitmovin Player
-
-     - Parameters:
-        - player: Bitmovin Player instance to track
-        - customerKey: Conviva customerKey
-        - config: ConvivaConfiguration object (see ConvivaConfiguration for more information)
-     */
+    /// Initialize a new Bitmovin Conviva Analytics object to track metrics from Bitmovin Player
+    ///  
+    /// - Parameters:
+    ///    - player: Bitmovin Player instance to track
+    ///    - customerKey: Conviva customerKey
+    ///    - config: ConvivaConfiguration object (see ConvivaConfiguration for more information)
     public convenience init(
         player: Player,
         customerKey: String,
@@ -85,7 +83,15 @@ public final class ConvivaAnalytics: NSObject {
             config: config
         )
     }
-
+    
+    /// Initialize a new Bitmovin Conviva Analytics object to track metrics from Bitmovin Player.
+    ///
+    /// Use this initializer if you plan to manually start VST tracking **before** a `Player` instance is created.
+    /// Once the `Player` instance is created, attach it using the `attach(player:)` method.
+    ///
+    /// - Parameters:
+    ///   - customerKey: Conviva customerKey
+    ///   - config: ConvivaConfiguration object (see ConvivaConfiguration for more information)
     public convenience init(
         customerKey: String,
         config: ConvivaConfiguration = ConvivaConfiguration()
@@ -285,6 +291,11 @@ public final class ConvivaAnalytics: NSObject {
         logger.debugLog(message: "Tracking resumed.")
     }
 
+    /// Attaches a `Player` instance to the Conviva Analytics object.
+    /// We suggest to call this method as soon as the `Player` instance is initialized to not mis any tracking.
+    ///
+    /// Has no effect if there is already an `Player` instance set. Use the `ConvivaAnalytics.init` without `player`
+    /// if you plan to attach an `Player` instance later in the life-cycle.
     public func attach(player: Player) {
         if self.player != nil {
             logger.debugLog(

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -83,7 +83,7 @@ public final class ConvivaAnalytics: NSObject {
             config: config
         )
     }
-    
+
     /// Initialize a new Bitmovin Conviva Analytics object to track metrics from Bitmovin Player.
     ///
     /// Use this initializer if you plan to manually start VST tracking **before** a `Player` instance is created.

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -88,7 +88,7 @@ public final class ConvivaAnalytics: NSObject {
 
     public convenience init(
         customerKey: String,
-        config: ConvivaConfiguration
+        config: ConvivaConfiguration = ConvivaConfiguration()
     ) throws {
         try self.init(
             nil,

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -515,7 +515,7 @@ private extension ConvivaAnalytics {
         )
     }
 
-    private func buildAdInfo(adStartedEvent: AdStartedEvent) -> [String: Any] {
+    private func buildAdInfo(adStartedEvent: AdStartedEvent, player: Player) -> [String: Any] {
         var adInfo = [String: Any]()
 
         adInfo["c3.ad.id"] = notAvailable
@@ -538,7 +538,7 @@ private extension ConvivaAnalytics {
 
         adInfo["c3.ad.position"] = AdEventUtil.parseAdPosition(
             event: adStartedEvent,
-            contentDuration: adStartedEvent.duration
+            contentDuration: player.duration
         ).rawValue
         adInfo[CIS_SSDK_METADATA_DURATION] = adStartedEvent.duration
         adInfo[CIS_SSDK_METADATA_IS_LIVE] = videoAnalytics.getMetadataInfo()[CIS_SSDK_METADATA_IS_LIVE]
@@ -732,8 +732,8 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     }
 
     // MARK: - Ad events
-    func onAdStarted(_ event: AdStartedEvent) {
-        let adInfo = buildAdInfo(adStartedEvent: event)
+    func onAdStarted(_ event: AdStartedEvent, player: Player) {
+        let adInfo = buildAdInfo(adStartedEvent: event, player: player)
         adAnalytics.reportAdLoaded(adInfo)
         adAnalytics.reportAdStarted(adInfo)
         adAnalytics.reportAdMetric(

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -79,7 +79,6 @@ public final class ConvivaAnalytics: NSObject {
         customerKey: String,
         config: ConvivaConfiguration = ConvivaConfiguration()
     ) throws {
-        self.player = player
         self.customerKey = customerKey
         self.config = config
 

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -74,10 +74,33 @@ public final class ConvivaAnalytics: NSObject {
         - customerKey: Conviva customerKey
         - config: ConvivaConfiguration object (see ConvivaConfiguration for more information)
      */
-    public init(
-        player: Player? = nil,
+    public convenience init(
+        player: Player,
         customerKey: String,
         config: ConvivaConfiguration = ConvivaConfiguration()
+    ) throws {
+        try self.init(
+            player,
+            customerKey: customerKey,
+            config: config
+        )
+    }
+
+    public convenience init(
+        customerKey: String,
+        config: ConvivaConfiguration
+    ) throws {
+        try self.init(
+            nil,
+            customerKey: customerKey,
+            config: config
+        )
+    }
+
+    private init(
+        _ player: Player?,
+        customerKey: String,
+        config: ConvivaConfiguration
     ) throws {
         self.customerKey = customerKey
         self.config = config

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -400,6 +400,7 @@ private extension ConvivaAnalytics {
     // MARK: - meta data handling
     private func buildContentMetadata() {
         let sourceConfig = player?.source?.sourceConfig
+        contentMetadataBuilder.assetName = sourceConfig?.title
 
         var customInternTags: [String: Any] = [
             "integrationVersion": version

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerHelper.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerHelper.swift
@@ -29,7 +29,7 @@ final class BitmovinPlayerHelper: NSObject {
         }
     }
 
-    var version: String {
+    static var version: String {
         PlayerFactory.sdkVersion
     }
 }

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
@@ -111,7 +111,7 @@ extension BitmovinPlayerListener: PlayerListener {
 
     // MARK: - Ad events
     func onAdStarted(_ event: AdStartedEvent, player: Player) {
-        delegate?.onAdStarted(event)
+        delegate?.onAdStarted(event, player: player)
     }
 
     func onAdFinished(_ event: AdFinishedEvent, player: Player) {

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListener.swift
@@ -43,7 +43,7 @@ extension BitmovinPlayerListener: PlayerListener {
     }
 
     func onTimeChanged(_ event: TimeChangedEvent, player: Player) {
-        delegate?.onTimeChanged()
+        delegate?.onTimeChanged(player: player)
     }
 
     func onPlayerError(_ event: PlayerErrorEvent, player: Player) {
@@ -89,7 +89,7 @@ extension BitmovinPlayerListener: PlayerListener {
     }
 
     func onStallEnded(_ event: StallEndedEvent, player: Player) {
-        delegate?.onStallEnded()
+        delegate?.onStallEnded(player: player)
     }
 
     // MARK: - Seek / Timeshift events
@@ -98,7 +98,7 @@ extension BitmovinPlayerListener: PlayerListener {
     }
 
     func onSeeked(_ event: SeekedEvent, player: Player) {
-        delegate?.onSeeked()
+        delegate?.onSeeked(player: player)
     }
 
     func onTimeShift(_ event: TimeShiftEvent, player: Player) {

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
@@ -13,7 +13,7 @@ protocol BitmovinPlayerListenerDelegate: AnyObject {
     func onEvent(_ event: Event)
     func onSourceUnloaded()
     func onSourceLoaded()
-    func onTimeChanged()
+    func onTimeChanged(player: Player)
     func onPlayerError(_ event: PlayerErrorEvent)
     func onSourceError(_ event: SourceErrorEvent)
 
@@ -26,11 +26,11 @@ protocol BitmovinPlayerListenerDelegate: AnyObject {
     func onPaused()
     func onPlaybackFinished()
     func onStallStarted()
-    func onStallEnded()
+    func onStallEnded(player: Player)
 
     // MARK: - Seek / Timeshift events
     func onSeek(_ event: SeekEvent)
-    func onSeeked()
+    func onSeeked(player: Player)
     func onTimeShift(_ event: TimeShiftEvent)
     func onTimeShifted()
 

--- a/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
+++ b/BitmovinConvivaAnalytics/Classes/Helper/BitmovinPlayerListenerDelegate.swift
@@ -35,7 +35,7 @@ protocol BitmovinPlayerListenerDelegate: AnyObject {
     func onTimeShifted()
 
     // MARK: - Ad events
-    func onAdStarted(_ event: AdStartedEvent)
+    func onAdStarted(_ event: AdStartedEvent, player: Player)
     func onAdFinished()
     func onAdSkipped(_ event: AdSkippedEvent)
     func onAdError(_ event: AdErrorEvent)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Warning logs in case the `viewerId` or `applicationName` is missing
+- Possibility to start session tracking without an `Player` instance
+  - `ConvivaAnalytics.init(customerKey:config:)` initializer without a `Player`
+  - `ConvivaAnalytics.attach(player:)` to attach the `Player` at a later point in the session life-cycle
 
 ### Fixed
 - Wrong initial Content Length reported when pre-roll ads are present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Warning logs in case the `viewerId` or `applicationName` is missing
-- Possibility to start session tracking without an `Player` instance
+- Possibility to start session tracking without a `Player` instance
   - `ConvivaAnalytics.init(customerKey:config:)` initializer without a `Player`
   - `ConvivaAnalytics.attach(player:)` to attach the `Player` at a later point in the session life-cycle
 

--- a/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
+++ b/Example/BitmovinConvivaAnalytics.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		37756EC2216F9AA50041806D /* CustomEventsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EC1216F9AA50041806D /* CustomEventsTest.swift */; };
 		37756EC42170764E0041806D /* SpecHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37756EC32170764E0041806D /* SpecHelper.swift */; };
 		37B615A02C775567009511D9 /* SourceTestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B6159F2C77555E009511D9 /* SourceTestDouble.swift */; };
+		37C28E5B2C7885E800737FBC /* LatePlayerAttachingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C28E5A2C7885E800737FBC /* LatePlayerAttachingTest.swift */; };
 		37EB3CD3216B70D70093F085 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB3CD1216B70650093F085 /* TestHelper.swift */; };
 		37EB3CD4216B70DA0093F085 /* BitmovinPlayerTestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB3CC7216B6E3F0093F085 /* BitmovinPlayerTestDouble.swift */; };
 		44D4DC502841032B00C0BE9D /* CISAnalyticsCreatorTestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D4DC4F2841032B00C0BE9D /* CISAnalyticsCreatorTestDouble.swift */; };
@@ -84,6 +85,7 @@
 		37756EC32170764E0041806D /* SpecHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecHelper.swift; sourceTree = "<group>"; };
 		37B6159E2C774236009511D9 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = SOURCE_ROOT; };
 		37B6159F2C77555E009511D9 /* SourceTestDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceTestDouble.swift; sourceTree = "<group>"; };
+		37C28E5A2C7885E800737FBC /* LatePlayerAttachingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatePlayerAttachingTest.swift; sourceTree = "<group>"; };
 		37EB3CC7216B6E3F0093F085 /* BitmovinPlayerTestDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BitmovinPlayerTestDouble.swift; path = Doubles/BitmovinPlayerTestDouble.swift; sourceTree = "<group>"; };
 		37EB3CD1216B70650093F085 /* TestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		3C5797E6D291A3F208E7499E /* Pods_BitmovinConvivaAnalytics_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BitmovinConvivaAnalytics_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -290,6 +292,7 @@
 				37756EAE216F8DF00041806D /* Helpers */,
 				37EB3CC6216B6D2B0093F085 /* Doubles */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				37C28E5A2C7885E800737FBC /* LatePlayerAttachingTest.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -749,6 +752,7 @@
 				37756EC2216F9AA50041806D /* CustomEventsTest.swift in Sources */,
 				44D4DC52284119E700C0BE9D /* CISAnalyticsTestDouble.swift in Sources */,
 				37EB3CD4216B70DA0093F085 /* BitmovinPlayerTestDouble.swift in Sources */,
+				37C28E5B2C7885E800737FBC /* LatePlayerAttachingTest.swift in Sources */,
 				44D4DC5428411DE400C0BE9D /* CISVideoAnalyticsTestDouble.swift in Sources */,
 				37B615A02C775567009511D9 /* SourceTestDouble.swift in Sources */,
 				37EB3CD3216B70D70093F085 /* TestHelper.swift in Sources */,

--- a/Example/BitmovinConvivaAnalytics/Base.lproj/Main.storyboard
+++ b/Example/BitmovinConvivaAnalytics/Base.lproj/Main.storyboard
@@ -91,6 +91,17 @@
                                     <action selector="setupPlayer:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="pdM-M2-Cgh"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YLt-uJ-a1f">
+                                <rect key="frame" x="20" y="557.33333333333337" width="390" height="35"/>
+                                <state key="normal" title="Send custom event">
+                                    <color key="titleColor" red="0.1215686275" green="0.6705882353" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <buttonConfiguration key="configuration" style="filled" title="Start session"/>
+                                <connections>
+                                    <action selector="sendCustomEvent:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="y4i-Ad-xIh"/>
+                                    <action selector="startSession:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="vOM-BI-JTG"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
@@ -111,11 +122,14 @@
                             <constraint firstItem="fQh-KT-xoi" firstAttribute="centerY" secondItem="8Dd-hJ-36w" secondAttribute="centerY" id="W26-cb-q04"/>
                             <constraint firstItem="HrS-Ed-xzX" firstAttribute="top" secondItem="3QL-eh-ZrN" secondAttribute="bottom" constant="18" id="WvM-e7-lT5"/>
                             <constraint firstItem="Jhg-y7-hrv" firstAttribute="trailing" secondItem="0nJ-z5-CEq" secondAttribute="trailing" id="Xgj-8c-sXF"/>
+                            <constraint firstItem="YLt-uJ-a1f" firstAttribute="leading" secondItem="Sdv-DY-6Hj" secondAttribute="leading" id="YAc-ED-WK6"/>
                             <constraint firstItem="Sdv-DY-6Hj" firstAttribute="trailing" secondItem="CH6-Cy-ZzH" secondAttribute="trailing" id="Zz3-mW-haT"/>
                             <constraint firstItem="HrS-Ed-xzX" firstAttribute="trailing" secondItem="Jhg-y7-hrv" secondAttribute="trailing" id="azn-fc-0ek"/>
                             <constraint firstItem="Sdv-DY-6Hj" firstAttribute="top" secondItem="jOh-oJ-5HR" secondAttribute="bottom" constant="16" id="bOZ-OY-PfM"/>
+                            <constraint firstItem="YLt-uJ-a1f" firstAttribute="top" secondItem="Sdv-DY-6Hj" secondAttribute="bottom" constant="16" id="blt-p8-NcZ"/>
                             <constraint firstItem="CH6-Cy-ZzH" firstAttribute="leading" secondItem="jOh-oJ-5HR" secondAttribute="trailing" constant="16" id="et0-ek-4Xs"/>
                             <constraint firstItem="Jhg-y7-hrv" firstAttribute="top" secondItem="0nJ-z5-CEq" secondAttribute="bottom" constant="16" id="isJ-67-sFZ"/>
+                            <constraint firstItem="YLt-uJ-a1f" firstAttribute="trailing" secondItem="Sdv-DY-6Hj" secondAttribute="trailing" id="n7p-kX-JFp"/>
                             <constraint firstItem="jOh-oJ-5HR" firstAttribute="top" secondItem="8Dd-hJ-36w" secondAttribute="bottom" constant="16" id="phJ-IH-9lH"/>
                             <constraint firstItem="8Dd-hJ-36w" firstAttribute="leading" secondItem="HrS-Ed-xzX" secondAttribute="leading" id="prr-Ti-jp2"/>
                             <constraint firstItem="8Dd-hJ-36w" firstAttribute="top" secondItem="HrS-Ed-xzX" secondAttribute="bottom" constant="16" id="uwM-7T-LZq"/>

--- a/Example/BitmovinConvivaAnalytics/ViewController.swift
+++ b/Example/BitmovinConvivaAnalytics/ViewController.swift
@@ -115,6 +115,8 @@ class ViewController: UIViewController {
     @IBAction func destroyPlayer(_ sender: Any) {
         convivaAnalytics?.release()
         player?.unload()
+        player?.destroy()
+        player = nil
     }
 
     @IBAction func pauseTracking(_ sender: Any) {

--- a/Example/BitmovinConvivaAnalytics/ViewController.swift
+++ b/Example/BitmovinConvivaAnalytics/ViewController.swift
@@ -53,32 +53,14 @@ class ViewController: UIViewController {
         let playerConfig = buildDefaultPlayerConfig(enableAds: adsSwitch.isOn)
         player = PlayerFactory.createPlayer(playerConfig: playerConfig)
 
-        let convivaConfig = ConvivaConfiguration()
-
-        // Set gatewayUrl ONLY in debug mode !!!
-        if let gatewayString = convivaGatewayString,
-            let gatewayUrl = URL(string: gatewayString) {
-            convivaConfig.gatewayUrl = gatewayUrl
-        }
-        convivaConfig.debugLoggingEnabled = true
-
-        var metadata = MetadataOverrides()
-        metadata.applicationName = "Bitmovin iOS Conviva integration example app"
-        metadata.viewerId = "awesomeViewerId"
-        metadata.custom = ["custom_tag": "Episode"]
-        metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
-
-        metadata.imaSdkVersion = IMAAdsLoader.sdkVersion()
-
-        do {
-            convivaAnalytics = try ConvivaAnalytics(
-                player: player,
-                customerKey: convivaCustomerKey,
-                config: convivaConfig
-            )
-            convivaAnalytics?.updateContentMetadata(metadataOverrides: metadata)
-        } catch {
-            NSLog("[ Example ] ConvivaAnalytics initialization failed with error: \(error)")
+        if convivaAnalytics == nil {
+            do {
+                convivaAnalytics = try setupConvivaAnalytics(player: player)
+            } catch {
+                NSLog("[ Example ] ConvivaAnalytics initialization failed with error: \(error)")
+            }
+        } else {
+            convivaAnalytics?.attach(player: player)
         }
 
         // Setup UI
@@ -92,6 +74,28 @@ class ViewController: UIViewController {
         playerUIView.addSubview(playerView)
 
         player.load(source: SourceFactory.createSource(from: vodSourceConfig))
+    }
+
+    func setupConvivaAnalytics(player: Player?) throws -> ConvivaAnalytics {
+        let convivaConfig = ConvivaConfiguration()
+
+        // Set gatewayUrl ONLY in debug mode !!!
+        if let gatewayString = convivaGatewayString,
+            let gatewayUrl = URL(string: gatewayString) {
+            convivaConfig.gatewayUrl = gatewayUrl
+        }
+        convivaConfig.debugLoggingEnabled = true
+
+        let convivaAnalytics = try ConvivaAnalytics(
+            player: player,
+            customerKey: convivaCustomerKey,
+            config: convivaConfig
+        )
+        convivaAnalytics.updateContentMetadata(
+            metadataOverrides: buildMetadataOverrides()
+        )
+
+        return convivaAnalytics
     }
 
     // MARK: - actions
@@ -122,4 +126,33 @@ class ViewController: UIViewController {
             attributes: ["at Time": "\(Int(player.currentTime))"]
         )
     }
+
+    @IBAction func startSession(_ sender: Any) {
+        do {
+            let convivaAnalytics = try setupConvivaAnalytics(player: player)
+
+            convivaAnalytics.updateContentMetadata(
+                metadataOverrides: buildMetadataOverrides(assetName: "Art of Motion")
+            )
+
+            try convivaAnalytics.initializeSession()
+
+            self.convivaAnalytics = convivaAnalytics
+        } catch {
+            NSLog("[ Example ] ConvivaAnalytics initialization failed with error: \(error)")
+        }
+    }
+}
+
+private func buildMetadataOverrides(assetName: String? = nil) -> MetadataOverrides {
+    var metadata = MetadataOverrides()
+    metadata.applicationName = "Bitmovin iOS Conviva integration example app"
+    metadata.viewerId = "awesomeViewerId"
+    metadata.custom = ["custom_tag": "Episode"]
+    metadata.additionalStandardTags = ["c3.cm.contentType": "VOD"]
+    metadata.imaSdkVersion = IMAAdsLoader.sdkVersion()
+    if let assetName {
+        metadata.assetName = assetName
+    }
+    return metadata
 }

--- a/Example/BitmovinConvivaAnalytics/ViewController.swift
+++ b/Example/BitmovinConvivaAnalytics/ViewController.swift
@@ -86,11 +86,20 @@ class ViewController: UIViewController {
         }
         convivaConfig.debugLoggingEnabled = true
 
-        let convivaAnalytics = try ConvivaAnalytics(
-            player: player,
-            customerKey: convivaCustomerKey,
-            config: convivaConfig
-        )
+        let convivaAnalytics: ConvivaAnalytics
+        if let player {
+            convivaAnalytics = try ConvivaAnalytics(
+                player: player,
+                customerKey: convivaCustomerKey,
+                config: convivaConfig
+            )
+        } else {
+            convivaAnalytics = try ConvivaAnalytics(
+                customerKey: convivaCustomerKey,
+                config: convivaConfig
+            )
+        }
+
         convivaAnalytics.updateContentMetadata(
             metadataOverrides: buildMetadataOverrides()
         )

--- a/Example/Tests/ContentMetadataTest.swift
+++ b/Example/Tests/ContentMetadataTest.swift
@@ -51,6 +51,12 @@ class ContentMetadataTest: QuickSpec {
                 }
             }
             context("when initializing session") {
+                var sourceDouble: SourceTestDouble!
+                beforeEach {
+                    sourceDouble = SourceTestDouble()
+
+                    _ = TestDouble(aClass: playerDouble!, name: "source", return: sourceDouble!)
+                }
                 it("set application name") {
                     playerDouble.fakePlayEvent() // to initialize session
                     let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "reportPlaybackRequested")
@@ -63,13 +69,11 @@ class ContentMetadataTest: QuickSpec {
                 it("set asset name") {
                     let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "reportPlaybackRequested")
 
-                    let playerConfig = PlayerConfig()
-                    _ = TestDouble(aClass: playerDouble!, name: "config", return: playerConfig)
-
                     let sourceConfig = SourceConfig(url: URL(string: "www.google.com.m3u8")!, type: .hls)
                     sourceConfig.title = "Art of Unit Test"
-                    let source = SourceFactory.createSource(from: sourceConfig)
-                    playerDouble.load(source: source)
+
+                    _ = TestDouble(aClass: sourceDouble!, name: "sourceConfig", return: sourceConfig)
+
                     playerDouble.fakePlayEvent() // to initialize session
                     expect(spy).to(
                         haveBeenCalled(withArgs: ["assetName": "Art of Unit Test"])

--- a/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
+++ b/Example/Tests/Doubles/BitmovinPlayerTestDouble.swift
@@ -25,42 +25,42 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
         guard let onReady = fakeListener?.onReady else {
             return
         }
-        onReady(ReadyEvent(), player)
+        onReady(ReadyEvent(), self)
     }
 
     func fakePlayEvent() {
         guard let onPlay = fakeListener?.onPlay else {
             return
         }
-        onPlay(PlayEvent(time: 1), player)
+        onPlay(PlayEvent(time: 1), self)
     }
 
     func fakePlayingEvent() {
         guard let onPlaying = fakeListener?.onPlaying else {
             return
         }
-        onPlaying(PlayingEvent(time: 1), player)
+        onPlaying(PlayingEvent(time: 1), self)
     }
 
     func fakePauseEvent() {
         guard let onPaused = fakeListener?.onPaused else {
             return
         }
-        onPaused(PausedEvent(time: 1), player)
+        onPaused(PausedEvent(time: 1), self)
     }
 
     func fakeStallStartedEvent() {
         guard let onStallStarted = fakeListener?.onStallStarted else {
             return
         }
-        onStallStarted(StallStartedEvent(), player)
+        onStallStarted(StallStartedEvent(), self)
     }
 
     func fakeStallEndedEvent() {
         guard let onStallEnded = fakeListener?.onStallEnded else {
             return
         }
-        onStallEnded(StallEndedEvent(), player)
+        onStallEnded(StallEndedEvent(), self)
     }
 
     func fakePlayerErrorEvent() {
@@ -73,7 +73,7 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
                 message: "Test player error",
                 data: nil
             ),
-            player
+            self
         )
     }
 
@@ -81,7 +81,7 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
         guard let onSourceError = fakeListener?.onSourceError else {
             return
         }
-        onSourceError(SourceErrorEvent(code: SourceError.Code.general, message: "Test source error", data: nil), player)
+        onSourceError(SourceErrorEvent(code: SourceError.Code.general, message: "Test source error", data: nil), self)
     }
 
     func fakeAdStartedEvent(position: String? = "pre") {
@@ -99,7 +99,7 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
                 position: position,
                 ad: BitmovinPlayerTestAd()
             ),
-            player
+            self
         )
     }
 
@@ -111,7 +111,7 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
             AdBreakStartedEvent(
                 adBreak: TestAdBreak(position: position)
             ),
-            player
+            self
         )
     }
 
@@ -123,7 +123,7 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
             AdBreakFinishedEvent(
                 adBreak: TestAdBreak(position: position)
             ),
-            player
+            self
         )
     }
 
@@ -131,42 +131,42 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
         guard let onTimeChanged = fakeListener?.onTimeChanged else {
             return
         }
-        onTimeChanged(TimeChangedEvent(currentTime: 1), player)
+        onTimeChanged(TimeChangedEvent(currentTime: 1), self)
     }
 
     func fakeSourceLoadedEvent() {
         guard let onSourceLoaded = fakeListener?.onSourceLoaded else {
             return
         }
-        onSourceLoaded(SourceLoadedEvent(source: fakeSource), player)
+        onSourceLoaded(SourceLoadedEvent(source: fakeSource), self)
     }
 
     func fakeSourceUnloadedEvent() {
         guard let onSourceUnloaded = fakeListener?.onSourceUnloaded else {
             return
         }
-        onSourceUnloaded(SourceUnloadedEvent(source: fakeSource), player)
+        onSourceUnloaded(SourceUnloadedEvent(source: fakeSource), self)
     }
 
     func fakeAdSkippedEvent() {
         guard let onAdSkipped = fakeListener?.onAdSkipped else {
             return
         }
-        onAdSkipped(AdSkippedEvent(ad: BitmovinPlayerTestAd()), player)
+        onAdSkipped(AdSkippedEvent(ad: BitmovinPlayerTestAd()), self)
     }
 
     func fakeAdFinishedEvent() {
         guard let onAdFinished = fakeListener?.onAdFinished else {
             return
         }
-        onAdFinished(AdFinishedEvent(ad: BitmovinPlayerTestAd()), player)
+        onAdFinished(AdFinishedEvent(ad: BitmovinPlayerTestAd()), self)
     }
 
     func fakeAdErrorEvent() {
         guard let onAdError = fakeListener?.onAdError else {
             return
         }
-        onAdError(AdErrorEvent(adItem: nil, code: 1_000, message: "Error Message", adConfig: nil), player)
+        onAdError(AdErrorEvent(adItem: nil, code: 1_000, message: "Error Message", adConfig: nil), self)
     }
 
     func fakeSeekEvent(position: TimeInterval = 0, seekTarget: TimeInterval = 0) {
@@ -176,7 +176,7 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
         // seek target returns -DBL_MAX when livestreaming
         let fromSeekPos = SeekPosition(source: fakeSource, time: position)
         let toSeekPos = SeekPosition(source: fakeSource, time: seekTarget)
-        onSeek(SeekEvent(from: fromSeekPos, to: toSeekPos), player)
+        onSeek(SeekEvent(from: fromSeekPos, to: toSeekPos), self)
     }
 
     func fakeTimeShiftEvent(position: TimeInterval = 0, seekTarget: TimeInterval = 0) {
@@ -184,42 +184,42 @@ class BitmovinPlayerTestDouble: BitmovinPlayerStub, TestDoubleDataSource {
             return
         }
         // seek target returns -DBL_MAX when livestreaming
-        onTimeShift(TimeShiftEvent(position: position, target: seekTarget, timeShift: 0), player)
+        onTimeShift(TimeShiftEvent(position: position, target: seekTarget, timeShift: 0), self)
     }
 
     func fakeSeekedEvent() {
         guard let onSeeked = fakeListener?.onSeeked else {
             return
         }
-        onSeeked(SeekedEvent(), player)
+        onSeeked(SeekedEvent(), self)
     }
 
     func fakeTimeShiftedEvent() {
         guard let onTimeShifted = fakeListener?.onTimeShifted else {
             return
         }
-        onTimeShifted(TimeShiftedEvent(), player)
+        onTimeShifted(TimeShiftedEvent(), self)
     }
 
     func fakePlaybackFinishedEvent() {
         guard let onPlaybackFinished = fakeListener?.onPlaybackFinished else {
             return
         }
-        onPlaybackFinished(PlaybackFinishedEvent(), player)
+        onPlaybackFinished(PlaybackFinishedEvent(), self)
     }
 
     func fakePlaylistTransitionEvent() {
         guard let onPlaylistTransition = fakeListener?.onPlaylistTransition else {
             return
         }
-        onPlaylistTransition(PlaylistTransitionEvent(from: fakeSource, to: fakeSource), player)
+        onPlaylistTransition(PlaylistTransitionEvent(from: fakeSource, to: fakeSource), self)
     }
 
     func fakeDestroyEvent() {
         guard let onDestroyEvent = fakeListener?.onDestroy else {
             return
         }
-        onDestroyEvent(DestroyEvent(), player)
+        onDestroyEvent(DestroyEvent(), self)
     }
 
     override func add(listener: PlayerListener) {

--- a/Example/Tests/LatePlayerAttachingTest.swift
+++ b/Example/Tests/LatePlayerAttachingTest.swift
@@ -1,0 +1,75 @@
+//
+//  ExternallyManagedSessionTests.swift
+//  BitmovinConvivaAnalytics_Tests
+//
+//  Created by Bitmovin on 30.01.19.
+//  Copyright © 2019 Bitmovin. All rights reserved.
+//
+
+import BitmovinConvivaAnalytics
+import BitmovinPlayer
+import ConvivaSDK
+import Nimble
+import Quick
+
+class LatePlayerAttachingTest: QuickSpec {
+    // swiftlint:disable:next function_body_length
+    override class func spec() {
+        var playerDouble: BitmovinPlayerTestDouble!
+
+        beforeEach {
+            playerDouble = BitmovinPlayerTestDouble()
+            TestHelper.shared.spyTracker.reset()
+            TestHelper.shared.mockTracker.reset()
+        }
+
+        var convivaAnalytics: ConvivaAnalytics!
+        beforeEach {
+            convivaAnalytics = try ConvivaAnalytics(customerKey: "")
+        }
+
+        afterEach {
+            if convivaAnalytics != nil {
+                convivaAnalytics = nil
+            }
+        }
+
+        context("initialize session") {
+            var spy: Spy!
+            beforeEach {
+                spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "reportPlaybackRequested")
+            }
+            context("without player") {
+                beforeEach {
+                    let playerConfig = PlayerConfig()
+                    _ = TestDouble(aClass: playerDouble, name: "config", return: playerConfig)
+                }
+
+                it("initializes the session with the externally provided asset name") {
+                    var metadata = MetadataOverrides()
+                    metadata.assetName = "MyAsset"
+                    convivaAnalytics.updateContentMetadata(metadataOverrides: metadata)
+                    try? convivaAnalytics.initializeSession()
+                    expect(spy).to(haveBeenCalled(withArgs: ["assetName": "MyAsset"]))
+                }
+            }
+
+            context("attaching the player while the session is already active") {
+                beforeEach {
+                    var metadata = MetadataOverrides()
+                    metadata.assetName = "MyAsset"
+                    convivaAnalytics.updateContentMetadata(metadataOverrides: metadata)
+                    try convivaAnalytics.initializeSession()
+
+                    convivaAnalytics.attach(player: playerDouble)
+                }
+
+                it("updates the session with available information") {
+                    let spy = Spy(aClass: CISVideoAnalyticsTestDouble.self, functionName: "setContentInfo")
+
+                    expect(spy).to(haveBeenCalled())
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ player.load(…);
 ### External VST tracking
 
 If your app needs additional setup steps which should be included in VST tracking, such as DRM token generation, before the `Player` instance can be initialized, 
-the `ConvivaAnalytics` can be initialized without an `Player` instance. Once the `Player` instance is created it can be attached.
+the `ConvivaAnalytics` can be initialized without a `Player` instance. Once the `Player` instance is created it can be attached.
 
 1. Create the `ConvivaAnalytics` instance with your `customerKey` and configuration.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,45 @@ If you want to use the same player instance for multiple playback, just load a n
 player.load(…);
 ```
 
+### External VST tracking
+
+If your app needs additional setup steps which should be included in VST tracking, such as DRM token generation, before the `Player` instance can be initialized, 
+the `ConvivaAnalytics` can be initialized without an `Player` instance. Once the `Player` instance is created it can be attached.
+
+1. Create the `ConvivaAnalytics` instance with your `customerKey` and configuration.
+
+```swift
+do {
+    convivaAnalytics = try ConvivaAnalytics(
+        customerKey: "YOUR-CONVIVA-CUSTOMER-KEY"
+    )
+} catch {
+    NSLog("[ Example ] ConvivaAnalytics initialization failed with error: \(error)")
+}
+```
+
+2. Conviva requires that the `assetName` is set at session initialization. Therefore ensure that you provide using the `MetadataOverrides` **before** initializing the tracking session.
+
+```swift
+var metadata = MetadataOverrides()
+metadata.assetName = "Your Asset Name"
+convivaAnalytics.updateContentMetadata(
+    metadataOverrides: metadata
+)
+
+// Initialize tracking session
+try convivaAnalytics.initializeSession()
+```
+
+3. Once your `Player` instance is ready attach it to the `ConvivaAnalytics` instance.
+
+```swift
+// ... Additional setup steps
+
+let player = PlayerFactory.createPlayer(...)
+convivaAnalytics.attach(player: player)
+``` 
+
 ## Limitations
 
 - Tracking multiple sources within a Playlist, and related use cases, introduced in Player iOS SDK version `v3` are not supported.


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
There are certain scenarios where VST tracking should start before a Player instance is created. Currently there is no way to start a Conviva Session without a player instance.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Extending the API to allow session initialization without a Player instance and adding a possibility to attach a Player instance at a later point in the life-cycle of the session.

### Notes
<!-- Anything worth pointing out -->
Manual session initialization API already existed and still needs to be used to start VST tracking.

### Manual testing instructions
I extended the Sample with a new `Start session` button. To test this, start the sample but first hit the `Destroy` button to stop and destroy the player/session, which automatically starts. (Of comment out `setupBitmovinPlayer` in `viewDidLoad`).
- Tap `Start Session` button
- Tap `Setup` button
- Double check in touchstone that the duration between those two actions is properly tracked as VST.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed
