### PR TITLE
Implement spm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Pods/
 
 # Intellij IDEA
 .idea/
+
+.build
+.vscodebuild

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "bitmovin-analytics-collector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/bitmovin/bitmovin-analytics-collector-ios.git",
+      "state" : {
+        "revision" : "2084a34ef569eee0de098fa5d503c4ec0aa96955",
+        "version" : "3.8.1"
+      }
+    },
+    {
+      "identity" : "conviva-ios-sdk-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Conviva/conviva-ios-sdk-spm.git",
+      "state" : {
+        "revision" : "62f136ddb511cbf7d6b110bf024aea6b548a86e6",
+        "version" : "4.0.51"
+      }
+    },
+    {
+      "identity" : "player-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/bitmovin/player-ios.git",
+      "state" : {
+        "revision" : "fa81ee31910b64c56131a648becaa4942b262553",
+        "version" : "3.75.0"
+      }
+    },
+    {
+      "identity" : "player-ios-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/bitmovin/player-ios-core.git",
+      "state" : {
+        "revision" : "fda8f4c76be8ebf63c56d5b40f26eb23dfc07c17",
+        "version" : "3.75.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "bitmovin-player-ios-analytics-conviva",
+    platforms: [.iOS(.v14), .tvOS(.v14),],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "BitmovinConvivaAnalytics",
+            targets: ["BitmovinConvivaAnalytics"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/bitmovin/player-ios.git", from: "3.75.0"),
+        .package(url: "https://github.com/Conviva/conviva-ios-sdk-spm.git", from: "4.0.51"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "BitmovinConvivaAnalytics",
+            dependencies: [
+                .product(name: "ConvivaSDK", package: "conviva-ios-sdk-spm"),
+                .product(name: "BitmovinPlayer", package: "player-ios"),
+            ],
+            path: "BitmovinConvivaAnalytics"
+        ),
+    ]
+)


### PR DESCRIPTION
### Problem
We try to migrate Cocoapods to Swift Package Manager (hereafter: SPM). This repo is one of the last packages that's not been migrated yet. 

### Solution
Implement SPM in conjunction with Cocoadpods...

### Checklist
- [ ] I added an update to `CHANGELOG.md` file
- [ ] I ran all the tests in the project and they succeed
- [ ] Figure out how to run tooling...
