### PR TITLE
Migrate Akamai CDN URLs to Bitmovin CDN

### DIFF
--- a/Example/BitmovinConvivaAnalytics/ViewController.swift
+++ b/Example/BitmovinConvivaAnalytics/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: UIViewController {
 
     var vodSourceConfig: SourceConfig {
         // swiftlint:disable:next force_unwrapping
-        var sourceUrl = URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!
+        var sourceUrl = URL(string: "https://cdn.bitmovin.com/content/assets/art-of-motion_drm/m3u8s/11331.m3u8")!
         if let streamString = streamUrlTextField.text, let url = URL(string: streamString) {
             sourceUrl = url
         }

--- a/Example/BitmovinConvivaAnalyticsTvOSExample/ViewController.swift
+++ b/Example/BitmovinConvivaAnalyticsTvOSExample/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
 
     var vodSourceConfig: SourceConfig {
         // swiftlint:disable:next force_unwrapping
-        let url = URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!
+        let url = URL(string: "https://cdn.bitmovin.com/content/assets/art-of-motion_drm/m3u8s/11331.m3u8")!
         let sourceConfig = SourceConfig(url: url, type: .hls)
         sourceConfig.title = "Art of Motion"
         return sourceConfig


### PR DESCRIPTION
### Problem
<!-- Describe the problem -->
We are moving away from Akamai CDN in favor of Bitmovin CDN.

### Solution
<!-- Describe how you solved the problem. Please consider adding new test cases! -->
Updated URLs to use the same assets from the Bitmovin CDN.

### Notes
<!-- Anything worth pointing out -->
N/A

### Checklist
- [x] I added an update to `CHANGELOG.md` file - not needed
- [x] I ran all the tests in the project and they succeed
