### PR TITLE
Added fix to handle NaN

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -519,7 +519,13 @@ private extension ConvivaAnalytics {
         guard let player, isSessionActive else { return }
 
         let reportPlayHeadTime: (_ analytics: CISStreamAnalyticsProtocol) -> Void = { analytics in
-            let currentTime = Int64(player.currentTime(.relativeTime) * 1_000)
+            let rawTime = player.currentTime(.relativeTime)
+            let currentTime: Int64
+            if rawTime.isNaN || rawTime.isInfinite {
+                currentTime = 0
+            } else {
+                currentTime = Int64(rawTime * 1_000)
+            }
             analytics.reportPlaybackMetric(
                 CIS_SSDK_PLAYBACK_METRIC_PLAY_HEAD_TIME,
                 value: currentTime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Handled Not a number (NaN) scenario for reportPlayHeadTime in ConvivaAnalytics.swift
+
 ## [3.6.1]
 
 ### Fixed


### PR DESCRIPTION
### Problem

A long pause during playback was causing `NaN` values to be generated in `reportPlayHeadTime`.

### Solution

Added a safeguard to handle cases where `NaN` is produced, ensuring the value is properly checked and handled before further processing.

### Notes

N/A

### Checklist

* [x] I added an update to `CHANGELOG.md` file
* [x] I ran all the tests in the project and they succeed
