### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ Pods/
 
 # Intellij IDEA
 .idea/
+
+# Swift Package Manager
+Package.resolved
+.build/
+.swiftpm/

--- a/BitmovinConvivaAnalytics.podspec
+++ b/BitmovinConvivaAnalytics.podspec
@@ -17,6 +17,7 @@ Conviva Analytics Integration for the Bitmovin Player iOS SDK
 
   s.source_files = 'BitmovinConvivaAnalytics/Classes/**/*.swift'
   s.resources = 'BitmovinConvivaAnalytics/Assets/*'
+  s.deprecated_in_favor_of = 'using SPM: https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva'
   s.swift_version = '5.0'
   s.cocoapods_version = '>= 1.9.0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Swift Package Manager support through a `Package.swift` exposing the `BitmovinConvivaAnalytics` library
+
 ## [3.6.1]
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "bitmovin-player-ios-analytics-conviva",
+    platforms: [.iOS(.v14), .tvOS(.v14)],
+    products: [
+        .library(
+            name: "BitmovinConvivaAnalytics",
+            targets: ["BitmovinConvivaAnalytics"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/bitmovin/player-ios.git", from: "3.75.0"),
+        .package(url: "https://github.com/Conviva/conviva-ios-sdk-spm.git", from: "4.0.51"),
+    ],
+    targets: [
+        .target(
+            name: "BitmovinConvivaAnalytics",
+            dependencies: [
+                .product(name: "ConvivaSDK", package: "conviva-ios-sdk-spm"),
+                .product(name: "BitmovinPlayer", package: "player-ios"),
+            ],
+            // The source folder also contains an `Assets/` Info.plist used by the
+            // CocoaPods build; scope the SPM target to the Swift sources only.
+            path: "BitmovinConvivaAnalytics",
+            exclude: ["Assets"],
+            sources: ["Classes"]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ Thank you for your contributions!
 
 ## Installation
 
+### Swift Package Manager
+
+In Xcode, go to `File > Add Package Dependencies…`, enter the repository URL and pick a version:
+
+```
+https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git
+```
+
+Or add it to the `dependencies` of your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/bitmovin/bitmovin-player-ios-analytics-conviva.git", from: "3.7.0")
+```
+
+Then add the `BitmovinConvivaAnalytics` product to the targets that need it. `BitmovinPlayer` and `ConvivaSDK` are resolved automatically as transitive dependencies.
+
+### CocoaPods
+
 BitmovinConvivaAnalytics is available through [CocoaPods](https://cocoapods.org). We depend on cocoapods version >= 1.9.0
 
 To install it, simply add the following line to your Podfile:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Or add it to the `dependencies` of your `Package.swift`:
 
 Then add the `BitmovinConvivaAnalytics` product to the targets that need it. `BitmovinPlayer` and `ConvivaSDK` are resolved automatically as transitive dependencies.
 
-### CocoaPods
+### CocoaPods (_Deprecated_)
+
+> CocoaPods will sunset at the end of 2026 and is therefore deprecated. See [this](https://community.bitmovin.com/t/cocoapods-deprecation-notice/3864) community post for more details.
 
 BitmovinConvivaAnalytics is available through [CocoaPods](https://cocoapods.org). We depend on cocoapods version >= 1.9.0
 


### PR DESCRIPTION
### Problem
We would like to fully migrate to SPM, dropping Cocoapods altogether. This package is the only one that doesn't support SPM yet.

### Solution
Add a `Package.swift` file to support SPM based installations

### Notes
Supersedes #89, same feature but stalled on the CLA, its author has since left our company.

The README pins `from: "3.7.0"` as a placeholder, please adjust it to the version you release
this under.

### Checklist
- [x] I added an update to `CHANGELOG.md` file
- [x] I ran all the tests in the project and they succeed